### PR TITLE
Fixes for 16.04 support and some improvements

### DIFF
--- a/lib/rock/packaging/debian.rb
+++ b/lib/rock/packaging/debian.rb
@@ -538,10 +538,23 @@ module Autoproj
                 @ruby_gems.uniq!
 
                 if target_platform.distribution_release_name
-                    # CASTXML vs. GCCXML
-                    if pkg.name =~ /typelib/ && !["xenial"].include?(target_platform.distribution_release_name)
-                        # remove the optional dependency on the rock-package of for all other except for xenial
-                        deps_rock_packages.delete(rock_release_prefix + "castxml")
+                    # CASTXML vs. GCCXML in typelib
+                    if pkg.name =~ /typelib/
+                        # add/remove the optional dependencies on the
+                        # rock-package depending on the target platform
+                        # there are typelib versions with and without the
+                        # optional depends. we know which platform requires
+                        # a particular dependency.
+                        if ["xenial"].include?(target_platform.distribution_release_name)
+                            deps_rock_packages.delete(rock_release_prefix + "castxml")
+                            deps_rock_packages.delete(rock_release_prefix + "gccxml")
+                            deps_osdeps_packages.push("castxml")
+                        else
+                            #todo: these need to checked on the other platforms
+                            deps_rock_packages.delete(rock_release_prefix + "castxml")
+                            deps_rock_packages.delete(rock_release_prefix + "gccxml")
+                            deps_osdeps_packages.push("gccxml")
+                        end
                     end
                     Packager.info "'#{pkg.name}' with (available) rock package dependencies: '#{deps_rock_packages}' -- #{pkg.dependencies}"
 

--- a/lib/rock/packaging/debiancontrol.rb
+++ b/lib/rock/packaging/debiancontrol.rb
@@ -1,0 +1,86 @@
+
+
+module Autoproj
+    module Packaging
+        @source = Hash.new
+        @packages = Array.new
+        
+        class DebianControl
+            # debian/control file reader/writer
+            # These files have the following layout:
+            #
+            # SourceBlock (having a Source key) 
+            # ^\s*$
+            # PackageBlock (having a Pacakge key)
+            # ^\s*$
+            # PackageBlock (having a Pacakge key)
+            # ...
+            # 
+            # There may be signatures interspersed, we don't handle them.
+            # Files may be compressed, we don't handle that either.
+            # A SourceBlock or PackageBlock is one or more Key/Value pairs as
+            # follows:
+            #
+            # ^<Key>: <Value>
+            # ^<Key>: <Value>
+            # ^\s<More Value>
+            # ...
+            # 
+            # Result is an array of hashes, preserving the order of the
+            # blocks, but not of the key/value pairs.
+            #
+            def self.parse(source, opts = {})
+                blocks = Array.new
+                hash = Hash.new
+                key = ""
+                source.each_line do |line|
+                    case line
+                    when /^(\S+)\s*:\s*(.*)\s*$/
+                        key = $1
+                        hash[key] = $2
+                    when /^\s(\s*\S.*)$/
+                        hash[key] << "\n" + $1
+                    when /^\s*$/
+                        blocks.push(hash) unless hash.empty?
+                        hash = Hash.new
+                        key = ""
+                    end
+                end
+                blocks.push(hash) unless hash.empty?
+                sourceblock = blocks.shift
+                self.new(sourceblock,blocks)
+            end #parse
+            
+            def self.generate(debctl, opts = {})
+                ret = ""
+                first_block = true
+                debctl.blocks.each do |elem|
+                    ret << "\n" if ! first_block
+                    first_block = false
+                    elem.each do |key,value|
+                        ret << key << ":"
+                        ret << "\n" if value.empty?
+                        value.each_line do |line|
+                            ret << " " if line !~ /^\s/
+                            ret << line
+                            ret << "\n" if line !~ /\n$/
+                        end
+                    end
+                end
+                ret
+            end #generate
+
+            def initialize(source, packages)
+                @source = source
+                @packages = packages
+            end #initialize
+
+            def blocks
+                [ @source ] + @packages
+            end
+
+            attr_reader :source
+            attr_reader :packages
+        end #DebianControl
+    end
+end

--- a/lib/rock/packaging/installer.rb
+++ b/lib/rock/packaging/installer.rb
@@ -95,6 +95,9 @@ module Autoproj
                 image_update(distribution, architecture)
                 image_prepare_hookdir(distribution, architecture, release_prefix)
 
+                CHROOT_EXTRA_DEBS.each do |extra_pkg|
+                    image_install_pkg(distribution, architecture, extra_pkg)
+                end
                 # If gem2deb_base_dir is given, then it will be tried to update
                 # (install a patched version of) gem2deb in the target chroot
                 # (if possible)
@@ -102,9 +105,6 @@ module Autoproj
                 if options[:patch_dir]
                     gem2deb_base_dir = File.join(options[:patch_dir],"gem2deb")
                     image_update_gem2deb(distribution, architecture, gem2deb_base_dir)
-                end
-                CHROOT_EXTRA_DEBS.each do |extra_pkg|
-                    image_install_pkg(distribution, architecture, extra_pkg)
                 end
             end
 

--- a/lib/rock/packaging/installer.rb
+++ b/lib/rock/packaging/installer.rb
@@ -194,11 +194,16 @@ module Autoproj
                     raise RuntimeError, "#{self} -- Execution: #{cmd} failed"
                 end
 
-                chroot_cmd(basepath,"dpkg -i /#{mountbase}/#{debfile}")
-
-                cmd = "sudo umount #{mountdir}"
-                if !system(cmd)
-                    raise RuntimeError, "#{self} -- Execution: #{cmd} failed"
+                begin
+                    if !gem2deb_test_runner_debfile.empty?
+                        chroot_cmd(basepath,"dpkg -i /#{mountbase}/#{gem2deb_test_runner_debfile}")
+                    end
+                    chroot_cmd(basepath,"dpkg -i /#{mountbase}/#{gem2deb_debfile}")
+                ensure
+                    cmd = "sudo umount #{mountdir}"
+                    if !system(cmd)
+                        raise RuntimeError, "#{self} -- Execution: #{cmd} failed"
+                    end
                 end
             end
 

--- a/lib/rock/packaging/installer.rb
+++ b/lib/rock/packaging/installer.rb
@@ -113,6 +113,17 @@ module Autoproj
                 chroot_cmd(basepath, "apt-get install -y #{pkg}")
             end
 
+            def self.image_install_debfile(distribution, architecture, debfile)
+                basepath = image_basepath(distribution, architecture)
+                begin
+                    chroot_cmd(basepath, "dpkg -i #{debfile}")
+                rescue
+                    #try again, fixing the dependencies beforehand.
+                    chroot_cmd(basepath, "apt-get -f install -y")
+                    chroot_cmd(basepath, "dpkg -i #{debfile}")
+                end
+            end
+
             # Get the base path to an image, e.g.
             #  base-trusty-amd64.cow
             def self.image_basepath(distribution, architecture)
@@ -201,9 +212,9 @@ module Autoproj
 
                 begin
                     if !gem2deb_test_runner_debfile.empty?
-                        chroot_cmd(basepath,"dpkg -i /#{mountbase}/#{gem2deb_test_runner_debfile}")
+                        image_install_debfile(distribution, architecture, "/#{mountbase}/#{gem2deb_test_runner_debfile}")
                     end
-                    chroot_cmd(basepath,"dpkg -i /#{mountbase}/#{gem2deb_debfile}")
+                    image_install_debfile(distribution, architecture, "/#{mountbase}/#{gem2deb_debfile}")
                 ensure
                     cmd = "sudo umount #{mountdir}"
                     if !system(cmd)

--- a/lib/rock/packaging/installer.rb
+++ b/lib/rock/packaging/installer.rb
@@ -179,12 +179,17 @@ module Autoproj
                         "Debian package directory: #{gem2deb_debs_dir} does not exist"
                 end
 
-                debfile = Dir.glob(File.join(gem2deb_debs_dir,"*.deb"))
-                if debfile.empty?
+                gem2deb_debfile = Dir.glob(File.join(gem2deb_debs_dir,"gem2deb_*.deb"))
+                if gem2deb_debfile.empty?
                     raise ArgumentError, "#{self} -- Cannot update gem2deb in chroot #{basepath}. " \
                         "Debian package directory: #{gem2deb_debs_dir} does not contain a deb file"
                 else
-                    debfile = File.basename(debfile.first)
+                    gem2deb_debfile = File.basename(gem2deb_debfile.first)
+                end
+
+                gem2deb_test_runner_debfile = Dir.glob(File.join(gem2deb_debs_dir,"gem2deb-test-runner_*.deb"))
+                if !gem2deb_test_runner_debfile.empty?
+                    gem2deb_test_runner_debfile = File.basename(gem2deb_test_runner_debfile.first)
                 end
 
                 mountbase = "mnt"


### PR DESCRIPTION
This allows deb_local to complete on Ubuntu 16.04, in a minimalistic rock environment. 
Completion of deb_local also requires some fixes to a few other packets:

- tools/orogen: missing hoe-yard in manifest.xml
- tools/pocolog: needs hoe-yard, not only hoe, and rbtree in manifest.xml
- tools/orocos.rb needs its gemspec fixed