### PR TITLE
deb: Fix creating the build environment for trusty

### DIFF
--- a/lib/rock/packaging/debian.rb
+++ b/lib/rock/packaging/debian.rb
@@ -1608,8 +1608,10 @@ module Autoproj
                     #
                     Dir.chdir(debian_ruby_name) do
 
-                        if patch_pkg_dir(options[:package_name], options[:patch_dir])
-                            dpkg_commit_changes("deb_autopackaging_overlay")
+                        if not options[:package_name].nil?
+                            if patch_pkg_dir(options[:package_name], options[:patch_dir])
+                                dpkg_commit_changes("deb_autopackaging_overlay")
+                            end
                         end
 
                         ################

--- a/lib/rock/packaging/installer.rb
+++ b/lib/rock/packaging/installer.rb
@@ -152,7 +152,9 @@ module Autoproj
                     Installer.info "Image #{basepath} already exists"
                 else
                     cmd = "sudo DIST=#{distribution} ARCH=#{architecture} "
-                    cmd+= "cowbuilder --create --basepath #{basepath}"
+                    cmd+= "cowbuilder --create --basepath #{basepath} "
+                    cmd+= "--distribution #{distribution} "
+                    cmd+= "--architecture #{architecture}"
 
                     if !system(cmd)
                         raise RuntimeError, "#{self} failed to create base-image: #{basepath}"
@@ -176,6 +178,8 @@ module Autoproj
 
                 # Set default ruby version
                 if ["trusty"].include?(distribution)
+                    #make sure a usable ruby version is installed
+                    image_install_pkg(distribution, architecture, "ruby2.0")
                     chroot_cmd(basepath, "dpkg-divert --add --rename --divert /usr/bin/ruby.divert /usr/bin/ruby")
                     chroot_cmd(basepath, "dpkg-divert --add --rename --divert /usr/bin/ruby.divert /usr/bin/ruby")
                     chroot_cmd(basepath, "dpkg-divert --add --rename --divert /usr/bin/gem.divert /usr/bin/gem")

--- a/lib/rock/packaging/templates/debian/changelog
+++ b/lib/rock/packaging/templates/debian/changelog
@@ -2,18 +2,18 @@
 
   * Package automatically built using autoproj-package debian
 <%begin%>
-<%if pkg.importer.kind_of?(Autobuild::Git) %>
-<% status = pkg.importer.status(pkg) %>
-   * repository: <%= pkg.importer.repository_id %>
-   * branch: <%= pkg.importer.current_branch(pkg) %>
+<%if package.importer.kind_of?(Autobuild::Git) %>
+<% status = package.importer.status(package) %>
+   * repository: <%= package.importer.repository_id %>
+   * branch: <%= package.importer.current_branch(package) %>
    * commit: <%= status.common_commit %>
-   * tag: <%= pkg.importer.tag %>
-<%elsif pkg.importer.kind_of?(Autobuild::SVN) %>
-   * repository: <%= pkg.importer.repository_id %>
-   * revision: <%= pkg.importer.revision %>
-<%elsif pkg.importer.kind_of?(Autobuild::ArchiveImporter) %>
-    * url: <%= pkg.importer.url %>
-    * filename: <%= pkg.importer.filename %>
+   * tag: <%= package.importer.tag %>
+<%elsif package.importer.kind_of?(Autobuild::SVN) %>
+   * repository: <%= package.importer.repository_id %>
+   * revision: <%= package.importer.revision %>
+<%elsif package.importer.kind_of?(Autobuild::ArchiveImporter) %>
+    * url: <%= package.importer.url %>
+    * filename: <%= package.importer.filename %>
 <%end%>
 <%rescue Exception => e%>
     * the repository and commit information could not be extracted

--- a/lib/rock/packaging/templates/debian/rules
+++ b/lib/rock/packaging/templates/debian/rules
@@ -33,7 +33,7 @@ pre-build::
 <% if package.class == Autobuild::Orogen %>
 	# Making sure orogen is executed before cmake is called
 	echo "pre-build: calling orogen in order to generate CMake layout"
-	$(env_setup) orogen <%= Autobuild::Orogen.orogen_options.join(" ") %> <%= pkg.orogen_options.join(" ") %> --corba --transports=corba,mqueue,typelib --type-export-policy=used <%= package.orogen_file %>
+	$(env_setup) orogen <%= Autobuild::Orogen.orogen_options.join(" ") %> <%= package.orogen_options.join(" ") %> --corba --transports=corba,mqueue,typelib --type-export-policy=used <%= package.orogen_file %>
 	#echo "Current directory including oroGen generated files"
 	#find . 
 <% end %>


### PR DESCRIPTION
cowbuilder passes most arguments to pbuilder, among them the --distribution and --architecture. The ARCH and DIST environment variables seem to be not used from a glance at the man pages.

The default trusty build environment does not have any ruby, and update-alternatives fails when the binary is missing.