### PR TITLE
Fixes

### DIFF
--- a/lib/rock/packaging/debian.rb
+++ b/lib/rock/packaging/debian.rb
@@ -1259,7 +1259,7 @@ module Autoproj
                     " options #{options}"
 
                 begin
-                    FileUtils.chdir File.join(build_dir, debian_pkg_name) do
+                    FileUtils.chdir File.join(build_dir, debian_pkg_name, target_platform.to_s.gsub("/","-")) do
                         if File.exists? "debian"
                             FileUtils.rm_rf "debian"
                         end
@@ -1269,6 +1269,7 @@ module Autoproj
                         FileUtils.mkdir versioned_build_dir
 
                         debian_tar_gz = Dir.glob("*.debian.tar.gz")
+                        debian_tar_gz.concat Dir.glob("*.debian.tar.xz")
                         if debian_tar_gz.empty?
                             raise RuntimeError, "#{self} could not find file: *.debian.tar.gz in #{Dir.pwd}"
                         else
@@ -1301,14 +1302,15 @@ module Autoproj
                                 raise RuntimeError, "Packager: '#{cmd}' failed"
                             end
                         end
-                    end
-                    filepath = Dir.glob("#{debian_pkg_name}/*.deb")
-                    if filepath.size < 1
-                        raise RuntimeError, "No debian file generated in #{Dir.pwd}"
-                    elsif filepath.size > 1
-                        raise RuntimeError, "More than one debian file available in #{Dir.pwd}: #{filepath}"
-                    else
-                        filepath = filepath.first
+
+                        filepath = Dir.glob("*.deb")
+                        if filepath.size < 1
+                            raise RuntimeError, "No debian file generated in #{Dir.pwd}"
+                        elsif filepath.size > 1
+                            raise RuntimeError, "More than one debian file available in #{Dir.pwd}: #{filepath}"
+                        else
+                            filepath = filepath.first
+                        end
                     end
                 rescue Exception => e
                     msg = "Package #{pkg_name} has not been packaged -- #{e}"

--- a/lib/rock/packaging/templates/debian/rules
+++ b/lib/rock/packaging/templates/debian/rules
@@ -57,10 +57,10 @@ DEB_CMAKE_INSTALL_PREFIX = $(rock_install_dir)
 DEB_CMAKE_EXTRA_FLAGS = -DCMAKE_SKIP_RPATH=OFF
 # Telling FindGEM.cmake to search for os packages using pkg-config and not for gems
 DEB_CMAKE_EXTRA_FLAGS += -DGEM_OS_PKG=TRUE
-# Disable ROCK Testing -- since running test on the OBS would require proper setting of path, etc. (see. data_processing/type_to_vector)
-DEB_CMAKE_EXTRA_FLAGS += -DROCK_TEST_ENABLED=OFF
 # Leaving RUBY_EXECUTABLE unset since it maps to a path of the user executing the upload script
-DEB_CMAKE_EXTRA_FLAGS += <%= package.defines.map { |k, v| "-D#{k}=\"#{v}\"" unless "#{k}" == "RUBY_EXECUTABLE" }.join(" ") %>
+DEB_CMAKE_EXTRA_FLAGS += <%= package.defines.map { |k, v| "-D#{k}=\"#{v}\"" unless "#{k}" == "RUBY_EXECUTABLE" || "#{k}" == "ROCK_TEST_ENABLED" || "#{k}" == "ROCK_TEST_LOG_DIR" }.join(" ") %>
+# Disable ROCK Testing -- since running test on the OBS would require proper setting of path, etc. (see. data_processing/type_to_vector)
+DEB_CMAKE_EXTRA_FLAGS += -DROCK_TEST_ENABLED=OFF -UROCK_TEST_LOG_DIR
 include /usr/share/cdbs/1/class/cmake.mk
 
 # END CMAKE


### PR DESCRIPTION
Let's do this again, this time for the right target branch...

build_local seems to be rather less used; for the typelib tests case i have no idea how that ever worked, given how typelib checks for doing testing since june 2016.