### PR TITLE
Autoproj separation

### DIFF
--- a/bin/deb_local
+++ b/bin/deb_local
@@ -42,14 +42,6 @@ def build_locally(packager, pkg_name, options)
     arguments += "--distributions #{distribution}"
     arguments += " "
     arguments += "--architectures #{architecture}"
-    arguments += " "
-    if options[:meta_depends]
-        arguments += "--meta #{pkg_name}"
-        arguments += " "
-        arguments += options[:meta_depends].join(" ")
-    else
-        arguments +="#{pkg_name}"
-    end
 
     # Create logging directory
     log_dir = File.join(packager.log_dir,"#{distribution}-#{architecture}")
@@ -61,7 +53,17 @@ def build_locally(packager, pkg_name, options)
     if options[:rebuild] || !packager.reprepro_has_package?(options[:debian_package_name], options[:release_name], distribution, architecture)
         puts "############### package #{pkg_name} ###################"
         rebuild_log = File.join(log_dir, "#{options[:debian_package_name]}-deb_local-rebuild.log")
-        cmd = "deb_package --package --rebuild #{arguments} > #{rebuild_log}"
+        cmd = "deb_package --rebuild #{arguments}"
+        cmd += " "
+        if options[:meta_depends]
+            cmd += "--meta #{pkg_name}"
+            cmd += " "
+            cmd += options[:meta_depends].join(" ")
+        else
+            cmd += "--package #{pkg_name}"
+        end
+        cmd += " > #{rebuild_log}"
+
         puts "Execution of: #{cmd}"
         if !system(cmd)
             raise RuntimeError, "Local rebuild of pkg #{pkg_name} failed -- see #{rebuild_log}"
@@ -98,7 +100,7 @@ def build_locally(packager, pkg_name, options)
         if packager.target_platform == Autoproj::Packaging::TargetPlatform.autodetect_target_platform
             puts "############### install #{pkg_name} #####################"
             install_log = File.join(log_dir,"#{options[:debian_package_name]}-deb_local-install.log")
-            cmd = "deb_package --install #{arguments} > #{install_log}"
+            cmd = "deb_package --install #{arguments} #{pkg_name} > #{install_log}"
             puts "Execution of: #{cmd}"
             if !system(cmd)
                 raise RuntimeError, "Local install of pkg #{pkg_name} failed -- see #{install_log}"
@@ -265,6 +267,9 @@ selected_rock_packages = o_selected_packages.select do |name|
     if pkg = Autoproj.manifest.package(name)
         Autoproj.debug "Package: #{name} is a known rock package"
         true
+    elsif Autoproj.manifest.metapackages.has_key?(sel)
+        Autoproj::Packaging.debug "Package: #{name} is a known rock meta package"
+        true
     elsif Autoproj::Packaging::GemDependencies::is_gem?(name)
         Autoproj.debug "Package: #{name} is a gem"
         packager.ruby_gems << [name, nil]
@@ -295,8 +300,12 @@ required_gems_versions = all_rock_packages[:gem_versions]
 # command line including they gem dependencies
 meta_packages = {}
 if o_custom_meta
-    meta_packages[o_custom_meta] = rock_packages.collect {|pkg| pkg.name } +
-                            required_gems
+    meta_packages[o_custom_meta] =
+        rock_packages.collect {|pkg| pkg.name } +
+        required_gems.select do |pkg|
+        native_name, is_osdeps = packager.native_dependency_name(pkg)
+        !is_osdeps
+    end
 end
 
 # check if the current collection in the manifest contains a
@@ -322,6 +331,8 @@ failed_gem_builds = []
 status = {}
 if !required_gems || required_gems.empty?
     puts "# No Gems to be packaged"
+elsif o_meta_only
+    # message output later
 else
     puts "# Packaging Gems ---- #{required_gems}"
     index = 0
@@ -369,7 +380,7 @@ failed_pkg_builds = []
 if !rock_packages || rock_packages.empty?
     puts "# No Rock Packages to be packaged"
 elsif o_meta_only
-    puts "# Creating only the meta package requested"
+    puts "# Creating only meta packages requested"
 else
     pkg_names = rock_packages.collect {|pkg| pkg.name }
     puts "# Packaging Rock Packages --- #{pkg_names}"
@@ -411,6 +422,7 @@ succeeded_meta_builds = []
 failed_meta_builds = []
 
 index = 0
+# o_build_meta is handled earlier: meta_packages will be setup accordingly.
 meta_packages.each do |pkg_name,depend_names|
     puts "# Creating meta package #{pkg_name} --- #{depend_names}"
 
@@ -418,10 +430,16 @@ meta_packages.each do |pkg_name,depend_names|
         pkg_build_options = build_options.dup
         pkg_build_options[:debian_package_name] = packager.debian_meta_name(pkg_name,true)
         pkg_build_options[:meta_depends] = depend_names
-        pkg_build_options[:rebuild] = false
+
         index += 1
         puts "    (#{index}) #{pkg_name}"
-        build_locally(packager, pkg_name, pkg_build_options)
+        if !o_dry_run
+            build_locally(packager, pkg_name, pkg_build_options)
+        end
+        succeeded_meta_builds << [index, pkg_name]
+    rescue SignalException => e
+        puts "Package building aborted by user"
+        exit 0
     rescue Exception => e
         puts "    package: #{pkg_name} building failed"
         puts e.message

--- a/bin/deb_local
+++ b/bin/deb_local
@@ -293,7 +293,7 @@ end
 
 # Compute dependencies for a given selection
 packager.package_set_order = ["orocos.toolchain","rock.core","rock"]
-all_rock_packages = packager.all_required_packages selection
+all_rock_packages = packager.filter_all_required_packages packager.all_required_packages selection
 rock_packages = all_rock_packages[:packages]
 required_gems = all_rock_packages[:gems]
 required_gems_versions = all_rock_packages[:gem_versions]

--- a/bin/deb_local
+++ b/bin/deb_local
@@ -4,6 +4,7 @@ require 'optparse'
 require 'autoproj'
 require 'autobuild'
 require 'rock/packaging'
+require 'rock/packaging/packageinfoask'
 require 'tempfile'
 require 'yaml'
 
@@ -200,6 +201,8 @@ else
 end
 
 packager = Autoproj::Packaging::Debian.new(build_options)
+package_info_ask = Autoproj::Packaging::PackageInfoAsk.new(:detect, Hash.new())
+
 if o_prepare_local_build
     puts "Preparing local building of packages"
     Autoproj::Packaging::Installer.install_all_requirements

--- a/bin/deb_local
+++ b/bin/deb_local
@@ -1,8 +1,6 @@
 #! /usr/bin/env ruby
 require 'find'
 require 'optparse'
-require 'autoproj'
-require 'autobuild'
 require 'rock/packaging'
 require 'rock/packaging/packageinfoask'
 require 'tempfile'
@@ -190,8 +188,6 @@ end
 
 o_selected_packages = options.parse(ARGV)
 
-Autoproj::Packaging.root_dir = Autoproj.root_dir
-
 build_options[:release_name] ||= 'local'
 if File.exists? o_patch_dir
     build_options[:patch_dir] = o_patch_dir
@@ -200,8 +196,10 @@ else
     exit 0
 end
 
-packager = Autoproj::Packaging::Debian.new(build_options)
 package_info_ask = Autoproj::Packaging::PackageInfoAsk.new(:detect, Hash.new())
+Autoproj::Packaging.root_dir = package_info_ask.root_dir
+Autoproj::Packaging::TargetPlatform.osdeps_release_tags= package_info_ask.osdeps_release_tags
+packager = Autoproj::Packaging::Debian.new(build_options)
 
 if o_prepare_local_build
     puts "Preparing local building of packages"
@@ -259,10 +257,6 @@ if o_deregister
     exit 0
 end
 
-Autoproj.silent = true
-root_dir  = Autoproj::CmdLine.initialize_root_directory
-selection = Autoproj::CmdLine.initialize_and_load(nil)
-
 packager.rock_autobuild_deps[:orogen] = [ package_info_ask.pkginfo_from_pkg(package_info_ask.package_by_name("orogen")) ]
 
 packager.rock_release_name = build_options[:release_name]
@@ -275,7 +269,7 @@ selected_rock_packages = o_selected_packages.select do |name|
     if pkg = package_info_ask.package(name)
         Autoproj::Packaging.debug "Package: #{name} is a known rock package"
         true
-    elsif Autoproj.manifest.metapackages.has_key?(sel)
+    elsif package_info_ask.is_metapackage?(name)
         Autoproj::Packaging.debug "Package: #{name} is a known rock meta package"
         true
     elsif Autoproj::Packaging::GemDependencies::is_gem?(name)
@@ -289,12 +283,14 @@ end
 
 Autoproj::Packaging.info "Selected_packages: #{o_selected_packages} --> rock_packages: #{selected_rock_packages}, gems: #{selected_gems}"
 
+selection = []
+
 # When a ruby gem shall be packaged directly there are no selected rock
 # packages, but selected ony
 is_gem = selected_rock_packages.empty? && !o_selected_packages.empty?
 if !is_gem
-    selection = Autoproj::CmdLine.initialize_and_load(selected_rock_packages)
-    selection = Autoproj::CmdLine.resolve_user_selection(selection).packages
+    selection = package_info_ask.autoproj_init_and_load(selected_rock_packages)
+    selection = package_info_ask.resolve_user_selection_packages(selection)
 end
 
 # Compute dependencies for a given selection
@@ -320,8 +316,8 @@ end
 # metapackage
 if o_build_meta
     o_selected_packages.each do |sel|
-        if Autoproj.manifest.metapackages.has_key?(sel)
-            meta_packages[sel] = Autoproj.manifest.metapackages[sel].packages.collect { |pkg| pkg.name }
+        if package_info_ask.is_metapackage?(sel)
+            meta_packages[sel] = package_info_ask.resolve_user_selection_packages([sel]).to_a
         end
     end
 end
@@ -395,7 +391,7 @@ else
     index = 0
     rock_pkginfos.each do |pkginfo|
         begin
-            if Autoproj.manifest.ignored?(pkginfo.name)
+            if package_info_ask.ignored?(pkginfo.name)
                 puts "    package is on the ignore list"
                 next
             end

--- a/bin/deb_local
+++ b/bin/deb_local
@@ -268,6 +268,7 @@ build_options[:packager] = packager
 packager.initialize_reprepro_repository(build_options[:release_name])
 puts "Building local package for: #{packager.target_platform}"
 
+selected_gems = []
 selected_rock_packages = o_selected_packages.select do |name|
     if pkg = Autoproj.manifest.package(name)
         Autoproj::Packaging.debug "Package: #{name} is a known rock package"
@@ -277,14 +278,14 @@ selected_rock_packages = o_selected_packages.select do |name|
         true
     elsif Autoproj::Packaging::GemDependencies::is_gem?(name)
         Autoproj::Packaging.debug "Package: #{name} is a gem"
-        packager.ruby_gems << [name, nil]
+        selected_gems << [name, nil]
         false
     else
         true
     end
 end
 
-Autoproj::Packaging.info "Selected_packages: #{o_selected_packages} --> rock_packages: #{selected_rock_packages}, gems: #{packager.ruby_gems}"
+Autoproj::Packaging.info "Selected_packages: #{o_selected_packages} --> rock_packages: #{selected_rock_packages}, gems: #{selected_gems}"
 
 # When a ruby gem shall be packaged directly there are no selected rock
 # packages, but selected ony
@@ -296,7 +297,7 @@ end
 
 # Compute dependencies for a given selection
 packager.package_set_order = ["orocos.toolchain","rock.core","rock"]
-all_rock_packages = packager.filter_all_required_packages packager.all_required_packages selection
+all_rock_packages = packager.filter_all_required_packages packager.all_required_packages selection, selected_gems
 rock_packages = all_rock_packages[:packages]
 required_gems = all_rock_packages[:gems]
 required_gems_versions = all_rock_packages[:gem_versions]

--- a/bin/deb_local
+++ b/bin/deb_local
@@ -70,7 +70,7 @@ def build_locally(packager, pkg_name, options)
             raise RuntimeError, "Local rebuild of pkg #{pkg_name} failed -- see #{rebuild_log}"
         end
         puts "############### build #{pkg_name} #####################"
-        debian_package_dir = packager.packaging_dir(options[:debian_package_name])
+        debian_package_dir = packager.packaging_dir_i(options[:debian_package_name])
         dsc_file = Dir.glob(File.join(debian_package_dir,"*.dsc")).first
         options[:log_file] ||= File.join(log_dir, "#{options[:debian_package_name]}-deb_local-build.log")
         puts "Building package from #{dsc_file} -- see log (#{options[:log_file]})"
@@ -263,6 +263,8 @@ Autoproj.silent = true
 root_dir  = Autoproj::CmdLine.initialize_root_directory
 selection = Autoproj::CmdLine.initialize_and_load(nil)
 
+packager.rock_autobuild_deps[:orogen] = [ package_info_ask.pkginfo_from_pkg(package_info_ask.package_by_name("orogen")) ]
+
 packager.rock_release_name = build_options[:release_name]
 build_options[:packager] = packager
 packager.initialize_reprepro_repository(build_options[:release_name])
@@ -270,7 +272,7 @@ puts "Building local package for: #{packager.target_platform}"
 
 selected_gems = []
 selected_rock_packages = o_selected_packages.select do |name|
-    if pkg = Autoproj.manifest.package(name)
+    if pkg = package_info_ask.package(name)
         Autoproj::Packaging.debug "Package: #{name} is a known rock package"
         true
     elsif Autoproj.manifest.metapackages.has_key?(sel)
@@ -296,9 +298,9 @@ if !is_gem
 end
 
 # Compute dependencies for a given selection
-packager.package_set_order = ["orocos.toolchain","rock.core","rock"]
-all_rock_packages = packager.filter_all_required_packages packager.all_required_packages selection, selected_gems
-rock_packages = all_rock_packages[:packages]
+package_info_ask.package_set_order = ["orocos.toolchain","rock.core","rock"]
+all_rock_packages = packager.filter_all_required_packages package_info_ask.all_required_packages selection, selected_gems
+rock_pkginfos = all_rock_packages[:pkginfos]
 required_gems = all_rock_packages[:gems]
 required_gems_versions = all_rock_packages[:gem_versions]
 
@@ -307,7 +309,7 @@ required_gems_versions = all_rock_packages[:gem_versions]
 meta_packages = {}
 if o_custom_meta
     meta_packages[o_custom_meta] =
-        rock_packages.collect {|pkg| pkg.name } +
+        rock_pkginfos.collect {|pkginfo| pkginfo.name } +
         required_gems.select do |pkg|
         native_name, is_osdeps = packager.native_dependency_name(pkg)
         !is_osdeps
@@ -383,38 +385,38 @@ end
 
 succeeded_pkg_builds = []
 failed_pkg_builds = []
-if !rock_packages || rock_packages.empty?
+if !rock_pkginfos || rock_pkginfos.empty?
     puts "# No Rock Packages to be packaged"
 elsif o_meta_only
     puts "# Creating only meta packages requested"
 else
-    pkg_names = rock_packages.collect {|pkg| pkg.name }
+    pkg_names = rock_pkginfos.collect {|pkginfo| pkginfo.name }
     puts "# Packaging Rock Packages --- #{pkg_names}"
     index = 0
-    rock_packages.each do |pkg|
+    rock_pkginfos.each do |pkginfo|
         begin
-            if Autoproj.manifest.ignored?(pkg.name)
+            if Autoproj.manifest.ignored?(pkginfo.name)
                 puts "    package is on the ignore list"
                 next
             end
             pkg_build_options = build_options.dup
-            pkg_build_options[:debian_package_name] = packager.debian_name(pkg,true)
-            if !o_no_deps || pkg.name =~ /#{o_selected_packages.first}/
+            pkg_build_options[:debian_package_name] = packager.debian_name_i(pkginfo,true)
+            if !o_no_deps || pkginfo.name =~ /#{o_selected_packages.first}/
                 index += 1
-                puts "    (#{index}) #{pkg.name}"
+                puts "    (#{index}) #{pkginfo.name}"
                 if !o_dry_run
-                    build_locally(packager, pkg.name, pkg_build_options)
+                    build_locally(packager, pkginfo.name, pkg_build_options)
                 end
-                succeeded_pkg_builds << [index, pkg.name]
+                succeeded_pkg_builds << [index, pkginfo.name]
             end
         rescue SignalException => e
             puts "Package building aborted by user"
             exit 0
         rescue Exception => e
-            puts "    package: #{pkg.name} building failed"
+            puts "    package: #{pkginfo.name} building failed"
             puts e.message
             puts e.backtrace.join("\n")
-            failed_pkg_builds << [index, pkg.name]
+            failed_pkg_builds << [index, pkginfo.name]
         ensure
             status['packages'] = { :succeeded => succeeded_pkg_builds,
                      :failed => failed_pkg_builds }

--- a/bin/deb_local
+++ b/bin/deb_local
@@ -189,6 +189,8 @@ end
 
 o_selected_packages = options.parse(ARGV)
 
+Autoproj::Packaging.root_dir = Autoproj.root_dir
+
 build_options[:release_name] ||= 'local'
 if File.exists? o_patch_dir
     build_options[:patch_dir] = o_patch_dir

--- a/bin/deb_local
+++ b/bin/deb_local
@@ -70,7 +70,7 @@ def build_locally(packager, pkg_name, options)
             raise RuntimeError, "Local rebuild of pkg #{pkg_name} failed -- see #{rebuild_log}"
         end
         puts "############### build #{pkg_name} #####################"
-        debian_package_dir = packager.packaging_dir_i(options[:debian_package_name])
+        debian_package_dir = packager.packaging_dir(options[:debian_package_name])
         dsc_file = Dir.glob(File.join(debian_package_dir,"*.dsc")).first
         options[:log_file] ||= File.join(log_dir, "#{options[:debian_package_name]}-deb_local-build.log")
         puts "Building package from #{dsc_file} -- see log (#{options[:log_file]})"
@@ -400,7 +400,7 @@ else
                 next
             end
             pkg_build_options = build_options.dup
-            pkg_build_options[:debian_package_name] = packager.debian_name_i(pkginfo,true)
+            pkg_build_options[:debian_package_name] = packager.debian_name(pkginfo,true)
             if !o_no_deps || pkginfo.name =~ /#{o_selected_packages.first}/
                 index += 1
                 puts "    (#{index}) #{pkginfo.name}"

--- a/bin/deb_local
+++ b/bin/deb_local
@@ -191,7 +191,7 @@ build_options[:release_name] ||= 'local'
 if File.exists? o_patch_dir
     build_options[:patch_dir] = o_patch_dir
 else
-    Autoproj.warn "Patch directory: #{patch_dir} does not exist"
+    Autoproj.warn "Patch directory: #{o_patch_dir} does not exist"
     exit 0
 end
 

--- a/bin/deb_local
+++ b/bin/deb_local
@@ -193,7 +193,7 @@ build_options[:release_name] ||= 'local'
 if File.exists? o_patch_dir
     build_options[:patch_dir] = o_patch_dir
 else
-    Autoproj.warn "Patch directory: #{o_patch_dir} does not exist"
+    Autoproj::Packaging.warn "Patch directory: #{o_patch_dir} does not exist"
     exit 0
 end
 
@@ -265,13 +265,13 @@ puts "Building local package for: #{packager.target_platform}"
 
 selected_rock_packages = o_selected_packages.select do |name|
     if pkg = Autoproj.manifest.package(name)
-        Autoproj.debug "Package: #{name} is a known rock package"
+        Autoproj::Packaging.debug "Package: #{name} is a known rock package"
         true
     elsif Autoproj.manifest.metapackages.has_key?(sel)
         Autoproj::Packaging.debug "Package: #{name} is a known rock meta package"
         true
     elsif Autoproj::Packaging::GemDependencies::is_gem?(name)
-        Autoproj.debug "Package: #{name} is a gem"
+        Autoproj::Packaging.debug "Package: #{name} is a gem"
         packager.ruby_gems << [name, nil]
         false
     else
@@ -279,7 +279,7 @@ selected_rock_packages = o_selected_packages.select do |name|
     end
 end
 
-Autoproj.info "Selected_packages: #{o_selected_packages} --> rock_packages: #{selected_rock_packages}, gems: #{packager.ruby_gems}"
+Autoproj::Packaging.info "Selected_packages: #{o_selected_packages} --> rock_packages: #{selected_rock_packages}, gems: #{packager.ruby_gems}"
 
 # When a ruby gem shall be packaged directly there are no selected rock
 # packages, but selected ony
@@ -341,7 +341,7 @@ else
             is_osdeps = false
             native_name, is_osdeps = packager.native_dependency_name(pkg)
             if is_osdeps
-                Autoproj.debug "Gem: #{pkg} is available as os dependency: #{native_name} (therefore it will not be build)"
+                Autoproj::Packaging.debug "Gem: #{pkg} is available as os dependency: #{native_name} (therefore it will not be build)"
                 next
             end
 
@@ -387,7 +387,7 @@ else
     index = 0
     rock_packages.each do |pkg|
         begin
-            if Autoproj.manifest.ignored?(pkg.name)
+            if Autoproj::Packaging.manifest.ignored?(pkg.name)
                 puts "    package is on the ignore list"
                 next
             end

--- a/bin/deb_local
+++ b/bin/deb_local
@@ -389,7 +389,7 @@ else
     index = 0
     rock_packages.each do |pkg|
         begin
-            if Autoproj::Packaging.manifest.ignored?(pkg.name)
+            if Autoproj.manifest.ignored?(pkg.name)
                 puts "    package is on the ignore list"
                 next
             end

--- a/bin/deb_package
+++ b/bin/deb_package
@@ -640,7 +640,12 @@ Dir.chdir(packager.build_dir) do
     if o_build_local
         begin
             packager.ruby_gems.each do |gem_name, gem_version|
-                filepath = packager.build_local_gem gem_name, :distributions => o_distributions, :verbose => Autobuild.verbose
+                pkg = Autoproj.manifest.packages[gem_name]
+                options =  {:distributions => o_distributions, :verbose => Autobuild.verbose}
+                if pkg && pkg.autobuild
+                    options[:parallel_build_level] = pkg.autobuild.parallel_build_level
+                end
+                filepath = packager.build_local_gem gem_name, options 
                 puts "Debian package created for gem '#{gem_name}': " + filepath
                 if o_dest_dir
                     puts "Copying debian package to destination folder: #{dest_dir}"

--- a/bin/deb_package
+++ b/bin/deb_package
@@ -1,6 +1,7 @@
 #! /usr/bin/env ruby
 # coding: utf-8
 require 'rock/packaging'
+require 'rock/packaging/packager'
 
 # Prevent deb_package from parallel execution since autoproj configuration loading
 # does not account for parallelism
@@ -10,6 +11,8 @@ lock_time = Time.now
 lock_file.flock(File::LOCK_EX)
 lock_wait_time_in_s = Time.now - lock_time
 Autoproj::Packaging.debug "deb_package: execution lock acquired after #{lock_wait_time_in_s} seconds"
+
+Autoproj::Packaging.root_dir = Autoproj.root_dir
 
 o_architectures = []
 o_distributions = []

--- a/bin/deb_package
+++ b/bin/deb_package
@@ -13,7 +13,8 @@ lock_file.flock(File::LOCK_EX)
 lock_wait_time_in_s = Time.now - lock_time
 Autoproj::Packaging.debug "deb_package: execution lock acquired after #{lock_wait_time_in_s} seconds"
 
-Autoproj::Packaging.root_dir = Autoproj.root_dir
+package_info_ask = Autoproj::Packaging::PackageInfoAsk.new(:detect, Hash.new())
+Autoproj::Packaging.root_dir = package_info_ask.root_dir
 
 o_architectures = []
 o_distributions = []
@@ -315,10 +316,10 @@ if o_distributions.size == 1
     end
 
     if !operating_system.empty?
-        Autoproj::OSDependencies.operating_system = operating_system
+        package_info_ask.osdeps_operating_system = operating_system
         puts "Custom setting of operating system to: #{operating_system}"
         if preferred_ruby_version
-            Autoproj::OSDependencies.alias(preferred_ruby_version,"ruby")
+            package_info_ask.osdeps_set_alias(preferred_ruby_version,"ruby")
             puts "Setting preferred ruby version: #{preferred_ruby_version}"
         end
     end
@@ -330,20 +331,14 @@ end
 if !o_architectures.empty?
     options[:architecture] = o_architectures.first
 end
+Autoproj::Packaging::TargetPlatform.osdeps_release_tags= package_info_ask.osdeps_release_tags
 packager = Autoproj::Packaging::Debian.new(options)
-package_info_ask = Autoproj::Packaging::PackageInfoAsk.new(:detect, Hash.new())
-
-# First load autoproj so that we can query what is a in rock defined
-# package and what is not
-Autoproj.silent = true
-root_dir  = Autoproj::CmdLine.initialize_root_directory
-selection = Autoproj::CmdLine.initialize_and_load(nil)
 
 packager.rock_autobuild_deps[:orogen] = [ package_info_ask.pkginfo_from_pkg(package_info_ask.package_by_name("orogen")) ]
 
 #if the name matches a move target directory, convert to package name
 o_selected_packages = o_selected_packages.map do |name|
-    Autoproj.manifest.moved_packages.each do |pkg_name,target_dir|
+    package_info_ask.moved_packages.each do |pkg_name,target_dir|
         if name == target_dir
             name = pkg_name
         end
@@ -353,7 +348,7 @@ end
 
 selected_gems = []
 selected_rock_packages = o_selected_packages.select do |name|
-    if pkg = Autoproj.manifest.package(name)
+    if package_info_ask.package(name)
         Autoproj::Packaging.warn "Package: #{name} is a known rock package"
         true
     elsif Autoproj::Packaging::GemDependencies::is_gem?(name)
@@ -366,8 +361,8 @@ selected_rock_packages = o_selected_packages.select do |name|
 end
 
 Autoproj::Packaging.info "selected_packages: #{o_selected_packages} --> rock_packages: #{selected_rock_packages}, gems: #{selected_gems}"
-selection = Autoproj::CmdLine.initialize_and_load(selected_rock_packages)
-selection = Autoproj::CmdLine.resolve_user_selection(selection).packages
+selection = package_info_ask.autoproj_init_and_load(selected_rock_packages)
+selection = package_info_ask.resolve_user_selection_packages(selection)
 
 packager.prepare
 
@@ -411,7 +406,7 @@ Dir.chdir(packager.build_dir) do
         end
 
         selection.each_with_index do |pkg_name, i|
-            if pkg = Autoproj.manifest.package(pkg_name)
+            if pkg = package_info_ask.package(pkg_name)
                 pkg = pkg.autobuild
                 Autoproj::Packaging.warn "Package: #{pkg_name} is a known rock package"
             else
@@ -472,11 +467,11 @@ Dir.chdir(packager.build_dir) do
         end
 
         selection.each do |pkg_name|
-            if pkg = Autoproj.manifest.package(pkg_name)
+            if pkg = package_info_ask.package(pkg_name)
                 pkg = pkg.autobuild
-                Autoproj.warn "Package: #{pkg_name} is a known rock package"
+                Autoproj::Packaging.warn "Package: #{pkg_name} is a known rock package"
             else
-                Autoproj.warn "Package: #{pkg_name} is not a known rock package (but maybe a ruby gem?)"
+                Autoproj::Packaging.warn "Package: #{pkg_name} is not a known rock package (but maybe a ruby gem?)"
                 next
             end
 
@@ -488,7 +483,7 @@ Dir.chdir(packager.build_dir) do
         #create the meta package
         if meta_depend_packages.empty?
             puts "Meta package #{o_meta} requested with no dependencies"
-        elsif pkg = Autoproj.manifest.package(o_meta)
+        elsif pkg = package_info_ask.package(o_meta)
             puts "Meta package #{o_meta} is a known rock package"
         else
             #maybe let the packager handle the name conversion
@@ -594,7 +589,7 @@ Dir.chdir(packager.build_dir) do
             packager.update_osdeps_lists(pkginfo, o_osdeps_list_dir)
         end
         all_packages[:gems].each do |pkg_name|
-            pkg = Autoproj.manifest.package(pkg_name)
+            pkg = package_info_ask.package(pkg_name)
             if !pkg.nil?
                 pkg = pkg.autobuild
                 pkginfo = package_info_ask.pkginfo_from_pkg(pkg)
@@ -663,7 +658,7 @@ Dir.chdir(packager.build_dir) do
     if o_build_local
         begin
             selected_gems.each do |gem_name, gem_version|
-                pkg = Autoproj.manifest.packages[gem_name]
+                pkg = package_info_ask.package(gem_name)
                 options =  {:distributions => o_distributions, :verbose => Autobuild.verbose}
                 if pkg && pkg.autobuild
                     options[:parallel_build_level] = pkg.autobuild.parallel_build_level
@@ -678,7 +673,7 @@ Dir.chdir(packager.build_dir) do
             end
 
             selection.each_with_index do |pkg_name, i|
-                if pkg = Autoproj.manifest.package(pkg_name)
+                if pkg = package_info_ask.package(pkg_name)
                     pkg = pkg.autobuild
                 else
                     Autoproj::Packaging.warn "Package: #{pkg_name} is not a known rock package (but maybe a ruby gem?)"
@@ -715,7 +710,7 @@ Dir.chdir(packager.build_dir) do
                 end
             end
             selection.each_with_index do |pkg_name, i|
-                if pkg = Autoproj.manifest.package(pkg_name)
+                if pkg = package_info_ask.package(pkg_name)
                     pkg = pkg.autobuild
                 else
                     Autoproj::Packaging.warn "Package: #{pkg_name} is not a known rock package (but maybe a ruby gem?)"

--- a/bin/deb_package
+++ b/bin/deb_package
@@ -2,6 +2,7 @@
 # coding: utf-8
 require 'rock/packaging'
 require 'rock/packaging/packager'
+require 'rock/packaging/packageinfoask'
 
 # Prevent deb_package from parallel execution since autoproj configuration loading
 # does not account for parallelism
@@ -330,6 +331,7 @@ if !o_architectures.empty?
     options[:architecture] = o_architectures.first
 end
 packager = Autoproj::Packaging::Debian.new(options)
+package_info_ask = Autoproj::Packaging::PackageInfoAsk.new(:detect, Hash.new())
 
 # First load autoproj so that we can query what is a in rock defined
 # package and what is not

--- a/bin/deb_package
+++ b/bin/deb_package
@@ -1,14 +1,15 @@
 #! /usr/bin/env ruby
+# coding: utf-8
 require 'rock/packaging'
 
 # Prevent deb_package from parallel execution since autoproj configuration loading
 # does not account for parallelism
 lock_file = File.open("/tmp/deb_package.lock",File::CREAT)
-Autoproj.debug "deb_package: waiting for execution lock"
+Autoproj::Packaging.debug "deb_package: waiting for execution lock"
 lock_time = Time.now
 lock_file.flock(File::LOCK_EX)
 lock_wait_time_in_s = Time.now - lock_time
-Autoproj.debug "deb_package: execution lock acquired after #{lock_wait_time_in_s} seconds"
+Autoproj::Packaging.debug "deb_package: execution lock acquired after #{lock_wait_time_in_s} seconds"
 
 o_architectures = []
 o_distributions = []
@@ -336,10 +337,10 @@ selection = Autoproj::CmdLine.initialize_and_load(nil)
 selected_gems = []
 selected_rock_packages = o_selected_packages.select do |name|
     if pkg = Autoproj.manifest.package(name)
-        Autoproj.warn "Package: #{name} is a known rock package"
+        Autoproj::Packaging.warn "Package: #{name} is a known rock package"
         true
     elsif Autoproj::Packaging::GemDependencies::is_gem?(name)
-        Autoproj.warn "Package: #{name} is a gem"
+        Autoproj::Packaging.warn "Package: #{name} is a gem"
         packager.ruby_gems << [name, o_package_version]
         false
     else
@@ -347,7 +348,7 @@ selected_rock_packages = o_selected_packages.select do |name|
     end
 end
 
-Autoproj.info "selected_packages: #{o_selected_packages} --> rock_packages: #{selected_rock_packages}, gems: #{selected_gems}"
+Autoproj::Packaging.info "selected_packages: #{o_selected_packages} --> rock_packages: #{selected_rock_packages}, gems: #{selected_gems}"
 selection = Autoproj::CmdLine.initialize_and_load(selected_rock_packages)
 selection = Autoproj::CmdLine.resolve_user_selection(selection).packages
 
@@ -374,7 +375,7 @@ end
 # and not the pattern matched to other packages, e.g. for orogen
 selection = selection.select do |pkg_name, i|
     if o_selected_packages.empty? or o_selected_packages.include?(pkg_name)
-        Autoproj.info "Package: #{pkg_name} is in selection"
+        Autoproj::Packaging.info "Package: #{pkg_name} is in selection"
         true
     else
         false
@@ -389,7 +390,7 @@ Dir.chdir(packager.build_dir) do
         Autobuild.do_update = true
 
         packager.ruby_gems.each do |pkg_name, version|
-            Autoproj.info "Converting ruby gem: '#{pkg_name}'"
+            Autoproj::Packaging.info "Converting ruby gem: '#{pkg_name}'"
             # Fails to be detected as normal package
             # so we assume it is a ruby gem
             packager.convert_gems([ [pkg_name, version] ], {:force_update => o_rebuild, :patch_dir => o_patch_dir})
@@ -401,9 +402,9 @@ Dir.chdir(packager.build_dir) do
         selection.each_with_index do |pkg_name, i|
             if pkg = Autoproj.manifest.package(pkg_name)
                 pkg = pkg.autobuild
-                Autoproj.warn "Package: #{pkg_name} is a known rock package"
+                Autoproj::Packaging.warn "Package: #{pkg_name} is a known rock package"
             else
-                Autoproj.warn "Package: #{pkg_name} is not a known rock package (but maybe a ruby gem?)"
+                Autoproj::Packaging.warn "Package: #{pkg_name} is not a known rock package (but maybe a ruby gem?)"
                 next
             end
 
@@ -638,7 +639,7 @@ Dir.chdir(packager.build_dir) do
                 if pkg = Autoproj.manifest.package(pkg_name)
                     pkg = pkg.autobuild
                 else
-                    Autoproj.warn "Package: #{pkg_name} is not a known rock package (but maybe a ruby gem?)"
+                    Autoproj::Packaging.warn "Package: #{pkg_name} is not a known rock package (but maybe a ruby gem?)"
                     next
                 end
 
@@ -651,7 +652,7 @@ Dir.chdir(packager.build_dir) do
                 end
             end
         rescue Exception => e
-            Autoproj.warn "Local build failed: #{e}"
+            Autoproj::Packaging.warn "Local build failed: #{e}"
             exit 10
         end
     end
@@ -673,7 +674,7 @@ Dir.chdir(packager.build_dir) do
                 if pkg = Autoproj.manifest.package(pkg_name)
                     pkg = pkg.autobuild
                 else
-                    Autoproj.warn "Package: #{pkg_name} is not a known rock package (but maybe a ruby gem?)"
+                    Autoproj::Packaging.warn "Package: #{pkg_name} is not a known rock package (but maybe a ruby gem?)"
                     next
                 end
                 debian_name = packager.debian_name(pkg, true)

--- a/bin/deb_package
+++ b/bin/deb_package
@@ -339,6 +339,8 @@ Autoproj.silent = true
 root_dir  = Autoproj::CmdLine.initialize_root_directory
 selection = Autoproj::CmdLine.initialize_and_load(nil)
 
+packager.rock_autobuild_deps[:orogen] = [ package_info_ask.pkginfo_from_pkg(package_info_ask.package_by_name("orogen")) ]
+
 #if the name matches a move target directory, convert to package name
 o_selected_packages = o_selected_packages.map do |name|
     Autoproj.manifest.moved_packages.each do |pkg_name,target_dir|
@@ -417,8 +419,10 @@ Dir.chdir(packager.build_dir) do
                 next
             end
 
+            pkginfo = package_info_ask.pkginfo_from_pkg(pkg)
+
             if o_skip && o_obs_dir
-                pkg_obs_dir = File.join(o_obs_dir, Autoproj::Packaging::Packager.obs_package_name(pkg))
+                pkg_obs_dir = File.join(o_obs_dir, Autoproj::Packaging::Packager.obs_package_name(pkginfo))
                 if File.directory?(pkg_obs_dir)
                     puts "skipping existing package #{pkg_name} (#{i + 1}/#{selection.size})"
                     next
@@ -441,11 +445,11 @@ Dir.chdir(packager.build_dir) do
                     options[:existing_source_dir] = pkg.srcdir
                 end
                 # just to update the required gem property
-                deps = packager.dependencies(pkg)
-                selected_gems.concat deps[:extra_gems]
-                packager.package(pkg, options)
+                selected_gems.concat pkginfo.dependencies[:extra_gems]
 
-                debian_pkg_name = packager.debian_name(pkg)
+                packager.package(pkginfo, options)
+
+                debian_pkg_name = packager.debian_name_i(pkginfo)
                 sync_packages << debian_pkg_name
             rescue Interrupt
                 raise
@@ -476,7 +480,9 @@ Dir.chdir(packager.build_dir) do
                 next
             end
 
-            meta_depend_packages << packager.debian_name(pkg)
+            pkginfo = package_info_ask.pkginfo_from_pkg(pkg)
+
+            meta_depend_packages << packager.debian_name_i(pkginfo)
         end
 
         #create the meta package
@@ -527,16 +533,16 @@ Dir.chdir(packager.build_dir) do
         # allow general parametrization for jobs
         packager.rock_release_name = "$release"
 
-        jenkins = Autoproj::Packaging::Jenkins.new(packager)
+        jenkins = Autoproj::Packaging::Jenkins.new(packager, package_info_ask)
 
-        packages = packager.all_required_rock_packages(selection)
+        packages = package_info_ask.all_required_rock_packages(selection, selected_gems)
         if packager.rock_release_name
             packages = packages.select do |pkg|
-                pkg_name = packager.debian_name(pkg, true)
+                pkginfo = package_info_ask.pkginfo_from_pkg(pkg)
+                pkg_name = packager.debian_name_i(pkginfo, true || with_prefix)
                 !packager.rock_release_platform.ancestorContains(pkg_name)
             end
         end
-
         if selection.size == 1
             pkg = packages.last
             puts "Creating Jenkins-job: #{pkg.name} -- #{pkg}"
@@ -556,7 +562,7 @@ Dir.chdir(packager.build_dir) do
     end
 
     if o_flow
-        jenkins = Autoproj::Packaging::Jenkins.new(packager)
+        jenkins = Autoproj::Packaging::Jenkins.new(packager, package_info_ask)
 
         puts "Creating FLOW-Job"
         options = { :force => o_overwrite }
@@ -580,17 +586,19 @@ Dir.chdir(packager.build_dir) do
     # Updating the osdeps files in a given directory
     if o_osdeps_list_dir
         puts "Updating osdep-lists: #{o_selected_packages} in directory #{o_osdeps_list_dir}"
-        all_packages = packager.filter_all_required_packages(packager.all_required_packages(selection, selected_gems))
+        all_packages = packager.filter_all_required_packages(package_info_ask.all_required_packages(selection, selected_gems))
         selected_gems.concat all_packages[:extra_gems]
         selected_gems.uniq!
-        packages = all_packages[:packages].map{ |pkg| pkg.name }
-        update_package_list =  packages + all_packages[:gems]
 
-        update_package_list.each do |pkg_name|
+        all_packages[:pkginfos].each do |pkginfo|
+            packager.update_osdeps_lists(pkginfo, o_osdeps_list_dir)
+        end
+        all_packages[:gems].each do |pkg_name|
             pkg = Autoproj.manifest.package(pkg_name)
             if !pkg.nil?
                 pkg = pkg.autobuild
-                packager.update_osdeps_lists(pkg, o_osdeps_list_dir)
+                pkginfo = package_info_ask.pkginfo_from_pkg(pkg)
+                packager.update_osdeps_lists(pkginfo, o_osdeps_list_dir)
             else
                 packager.update_osdeps_lists(pkg_name, o_osdeps_list_dir)
             end
@@ -612,12 +620,12 @@ Dir.chdir(packager.build_dir) do
         end
 
         i = 1
-        all_packages = packager.filter_all_required_packages(packager.all_required_packages(selection, selected_gems))
+        all_packages = packager.filter_all_required_packages(package_info_ask.all_required_packages(selection, selected_gems))
         selected_gems.concat all_packages[:extra_gems]
         selected_gems.uniq!
         all_gems  = all_packages[:gems]
 
-        jenkins = Autoproj::Packaging::Jenkins.new(packager)
+        jenkins = Autoproj::Packaging::Jenkins.new(packager, package_info_ask)
         puts "Creating Gem-Jobs for #{all_gems}"
 
         all_gems.each do |gem_name|
@@ -677,7 +685,8 @@ Dir.chdir(packager.build_dir) do
                     next
                 end
 
-                filepath = packager.build_local_package pkg, :distributions => o_distributions, :verbose => Autobuild.verbose
+                pkginfo = package_info_ask.pkginfo_from_pkg(pkg)
+                filepath = packager.build_local_package pkginfo, :distributions => o_distributions, :verbose => Autobuild.verbose
                 puts "Debian package created for package '#{pkg}': #{filepath}"
                 if o_dest_dir
                     puts "Copying debian package to destination folder: #{dest_dir}"
@@ -687,6 +696,7 @@ Dir.chdir(packager.build_dir) do
             end
         rescue Exception => e
             Autoproj::Packaging.warn "Local build failed: #{e}"
+            puts e.backtrace
             exit 10
         end
     end
@@ -711,7 +721,8 @@ Dir.chdir(packager.build_dir) do
                     Autoproj::Packaging.warn "Package: #{pkg_name} is not a known rock package (but maybe a ruby gem?)"
                     next
                 end
-                debian_name = packager.debian_name(pkg, true)
+                pkginfo = package_info_ask.pkginfo_from_pkg(pkg)
+                debian_name = packager.debian_name_i(pkginfo)
 
                 puts "Installing locally: '#{pkg.name}'"
                 packager.install debian_name, :distributions => o_distributions, :verbose => Autobuild.verbose

--- a/bin/deb_package
+++ b/bin/deb_package
@@ -449,7 +449,7 @@ Dir.chdir(packager.build_dir) do
 
                 packager.package(pkginfo, options)
 
-                debian_pkg_name = packager.debian_name_i(pkginfo)
+                debian_pkg_name = packager.debian_name(pkginfo)
                 sync_packages << debian_pkg_name
             rescue Interrupt
                 raise
@@ -482,7 +482,7 @@ Dir.chdir(packager.build_dir) do
 
             pkginfo = package_info_ask.pkginfo_from_pkg(pkg)
 
-            meta_depend_packages << packager.debian_name_i(pkginfo)
+            meta_depend_packages << packager.debian_name(pkginfo)
         end
 
         #create the meta package
@@ -539,7 +539,7 @@ Dir.chdir(packager.build_dir) do
         if packager.rock_release_name
             packages = packages.select do |pkg|
                 pkginfo = package_info_ask.pkginfo_from_pkg(pkg)
-                pkg_name = packager.debian_name_i(pkginfo, true || with_prefix)
+                pkg_name = packager.debian_name(pkginfo, true || with_prefix)
                 !packager.rock_release_platform.ancestorContains(pkg_name)
             end
         end
@@ -722,7 +722,7 @@ Dir.chdir(packager.build_dir) do
                     next
                 end
                 pkginfo = package_info_ask.pkginfo_from_pkg(pkg)
-                debian_name = packager.debian_name_i(pkginfo)
+                debian_name = packager.debian_name(pkginfo)
 
                 puts "Installing locally: '#{pkg.name}'"
                 packager.install debian_name, :distributions => o_distributions, :verbose => Autobuild.verbose

--- a/bin/deb_package
+++ b/bin/deb_package
@@ -453,7 +453,7 @@ Dir.chdir(packager.build_dir) do
             meta_depend_packages << debian_pkg_name
         end
 
-        selection.each_with_index do |pkg_name, i|
+        selection.each do |pkg_name|
             if pkg = Autoproj.manifest.package(pkg_name)
                 pkg = pkg.autobuild
                 Autoproj.warn "Package: #{pkg_name} is a known rock package"
@@ -462,8 +462,7 @@ Dir.chdir(packager.build_dir) do
                 next
             end
 
-            debian_pkg_name = packager.debian_name(pkg)
-            meta_depend_packages << debian_pkg_name
+            meta_depend_packages << packager.debian_name(pkg)
         end
 
         #create the meta package
@@ -484,7 +483,7 @@ Dir.chdir(packager.build_dir) do
             begin
                 # Only account for packages which are actually available
                 dependencies = meta_depend_packages.select do |pkg|
-                    packager.reprepro_has_package?(pkg, options[:release_name], distribution, architecture)
+                    packager.reprepro_has_package?(pkg, o_rock_release_name, distribution, o_architectures.first)
                 end
 
                 packager.package_meta(o_meta, dependencies, {:force_update => o_rebuild, :patch_dir => o_patch_dir, :package_set_dir => o_ps_dir})

--- a/bin/deb_package
+++ b/bin/deb_package
@@ -337,6 +337,16 @@ Autoproj.silent = true
 root_dir  = Autoproj::CmdLine.initialize_root_directory
 selection = Autoproj::CmdLine.initialize_and_load(nil)
 
+#if the name matches a move target directory, convert to package name
+o_selected_packages = o_selected_packages.map do |name|
+    Autoproj.manifest.moved_packages.each do |pkg_name,target_dir|
+        if name == target_dir
+            name = pkg_name
+        end
+    end
+    name
+end
+
 selected_gems = []
 selected_rock_packages = o_selected_packages.select do |name|
     if pkg = Autoproj.manifest.package(name)
@@ -354,12 +364,6 @@ end
 Autoproj::Packaging.info "selected_packages: #{o_selected_packages} --> rock_packages: #{selected_rock_packages}, gems: #{selected_gems}"
 selection = Autoproj::CmdLine.initialize_and_load(selected_rock_packages)
 selection = Autoproj::CmdLine.resolve_user_selection(selection).packages
-
-# Add all aliases, e.g. for tools/rtt --> rtt
-# basically for all packages that have been relocated using Autoproj's move_package command
-Autoproj::Packaging::Config.packages_aliases.each do |pkg_name, alias_name|
-    packager.add_package_alias pkg_name, alias_name
-end
 
 packager.prepare
 

--- a/bin/deb_package
+++ b/bin/deb_package
@@ -356,7 +356,7 @@ selected_rock_packages = o_selected_packages.select do |name|
         true
     elsif Autoproj::Packaging::GemDependencies::is_gem?(name)
         Autoproj::Packaging.warn "Package: #{name} is a gem"
-        packager.ruby_gems << [name, o_package_version]
+        selected_gems << [name, o_package_version]
         false
     else
         true
@@ -398,7 +398,7 @@ Dir.chdir(packager.build_dir) do
     if o_package
         Autobuild.do_update = true
 
-        packager.ruby_gems.each do |pkg_name, version|
+        selected_gems.each do |pkg_name, version|
             Autoproj::Packaging.info "Converting ruby gem: '#{pkg_name}'"
             # Fails to be detected as normal package
             # so we assume it is a ruby gem
@@ -440,6 +440,9 @@ Dir.chdir(packager.build_dir) do
                 if !o_use_remote_repository
                     options[:existing_source_dir] = pkg.srcdir
                 end
+                # just to update the required gem property
+                deps = packager.dependencies(pkg)
+                selected_gems.concat deps[:extra_gems]
                 packager.package(pkg, options)
 
                 debian_pkg_name = packager.debian_name(pkg)
@@ -451,13 +454,14 @@ Dir.chdir(packager.build_dir) do
                 next
             end
         end
+        selected_gems.uniq!
     end
 
     if o_meta
         #get the package names
         meta_depend_packages = []
 
-        packager.ruby_gems.each do |pkg_name, version|
+        selected_gems.each do |pkg_name, version|
             debian_pkg_name = packager.debian_ruby_name(pkg_name)
             puts "ruby gem: #{debian_pkg_name}"
             meta_depend_packages << debian_pkg_name
@@ -537,15 +541,18 @@ Dir.chdir(packager.build_dir) do
             pkg = packages.last
             puts "Creating Jenkins-job: #{pkg.name} -- #{pkg}"
             options[:force] = o_overwrite
-            jenkins.create_package_job(pkg, options)
+            extras = jenkins.create_package_job(pkg, options)
+            selected_gems.concat extras[:extra_gems]
         else
             packages.each_with_index do |pkg, i|
                 puts "(#{i+1}/#{packages.size}) Creating Jenkins-job: #{pkg.name} -- #{pkg}"
                 options[:force] = o_overwrite
-                jenkins.create_package_job(pkg, options)
+                extras = jenkins.create_package_job(pkg, options)
+                selected_gems.concat extras[:extra_gems]
             end
         end
 
+        selected_gems.uniq!
     end
 
     if o_flow
@@ -553,7 +560,9 @@ Dir.chdir(packager.build_dir) do
 
         puts "Creating FLOW-Job"
         options = { :force => o_overwrite }
-        jenkins.create_flow_job(o_flow, selection, o_flavor, options)
+        extras = jenkins.create_flow_job(o_flow, selection, selected_gems, o_flavor, options)
+        selected_gems.concat extras[:extra_gems]
+        selected_gems.uniq!
     end
 
     if o_control_job
@@ -571,7 +580,9 @@ Dir.chdir(packager.build_dir) do
     # Updating the osdeps files in a given directory
     if o_osdeps_list_dir
         puts "Updating osdep-lists: #{o_selected_packages} in directory #{o_osdeps_list_dir}"
-        all_packages = packager.filter_all_required_packages(packager.all_required_packages(selection))
+        all_packages = packager.filter_all_required_packages(packager.all_required_packages(selection, selected_gems))
+        selected_gems.concat all_packages[:extra_gems]
+        selected_gems.uniq!
         packages = all_packages[:packages].map{ |pkg| pkg.name }
         update_package_list =  packages + all_packages[:gems]
 
@@ -601,7 +612,9 @@ Dir.chdir(packager.build_dir) do
         end
 
         i = 1
-        all_packages = packager.filter_all_required_packages(packager.all_required_packages(selection))
+        all_packages = packager.filter_all_required_packages(packager.all_required_packages(selection, selected_gems))
+        selected_gems.concat all_packages[:extra_gems]
+        selected_gems.uniq!
         all_gems  = all_packages[:gems]
 
         jenkins = Autoproj::Packaging::Jenkins.new(packager)
@@ -641,7 +654,7 @@ Dir.chdir(packager.build_dir) do
 
     if o_build_local
         begin
-            packager.ruby_gems.each do |gem_name, gem_version|
+            selected_gems.each do |gem_name, gem_version|
                 pkg = Autoproj.manifest.packages[gem_name]
                 options =  {:distributions => o_distributions, :verbose => Autobuild.verbose}
                 if pkg && pkg.autobuild
@@ -680,7 +693,7 @@ Dir.chdir(packager.build_dir) do
 
     if o_install
         begin
-            packager.ruby_gems.each do |gem_name, gem_version|
+            selected_gems.each do |gem_name, gem_version|
                 is_osdeps = false
                 native_name, is_osdeps = packager.native_dependency_name(gem_name)
                 if !is_osdeps

--- a/bin/deb_package
+++ b/bin/deb_package
@@ -524,6 +524,13 @@ Dir.chdir(packager.build_dir) do
         jenkins = Autoproj::Packaging::Jenkins.new(packager)
 
         packages = packager.all_required_rock_packages(selection)
+        if packager.rock_release_name
+            packages = packages.select do |pkg|
+                pkg_name = packager.debian_name(pkg, true)
+                !packager.rock_release_platform.ancestorContains(pkg_name)
+            end
+        end
+
         if selection.size == 1
             pkg = packages.last
             puts "Creating Jenkins-job: #{pkg.name} -- #{pkg}"
@@ -562,7 +569,7 @@ Dir.chdir(packager.build_dir) do
     # Updating the osdeps files in a given directory
     if o_osdeps_list_dir
         puts "Updating osdep-lists: #{o_selected_packages} in directory #{o_osdeps_list_dir}"
-        all_packages = packager.all_required_packages(selection)
+        all_packages = packager.filter_all_required_packages(packager.all_required_packages(selection))
         packages = all_packages[:packages].map{ |pkg| pkg.name }
         update_package_list =  packages + all_packages[:gems]
 
@@ -592,7 +599,7 @@ Dir.chdir(packager.build_dir) do
         end
 
         i = 1
-        all_packages = packager.all_required_packages(selection)
+        all_packages = packager.filter_all_required_packages(packager.all_required_packages(selection))
         all_gems  = all_packages[:gems]
 
         jenkins = Autoproj::Packaging::Jenkins.new(packager)

--- a/bin/obs_package
+++ b/bin/obs_package
@@ -138,13 +138,14 @@ if o_list_build_projects
     exit 0
 end
 
-
 root_dir  = Autoproj::CmdLine.initialize_root_directory
 selection = Autoproj::CmdLine.initialize_and_load(o_selected_packages)
 selection = Autoproj::CmdLine.resolve_user_selection(selection).packages
 
 packager = Autoproj::Packaging::Debian.new(File.join(Autoproj.root_dir, "debian"))
 package_info_ask = Autoproj::Packaging::PackageInfoAsk.new(:detect, Hash.new())
+
+packager.rock_autobuild_deps[:orogen] = [ package_info_ask.pkginfo_from_pkg(package_info_ask.package_by_name("orogen")) ]
 
 packager.prepare
 
@@ -167,10 +168,11 @@ Dir.chdir(Autoproj::Packaging::OBS_BUILD_DIR) do
     if o_all_packages
         Autobuild.do_update = true
         selection.each_with_index do |pkg_name, i|
-            pkg = Autoproj.manifest.package(pkg_name).autobuild
+            pkg = package_info_ask.package_by_name(pkg_name)
+            pkginfo = package_info_ask.pkginfo_from_pkg(pkg)
 
             if o_skip_existing && o_obs_dir
-                pkg_obs_dir = File.join(o_obs_dir, Autoproj::Packaging::Packager.obs_package_name(pkg))
+                pkg_obs_dir = File.join(o_obs_dir, Autoproj::Packaging::Packager.obs_package_name(pkginfo))
                 if File.directory?(pkg_obs_dir)
                     puts "skipping existing package #{pkg_name} (#{i + 1}/#{selection.size})"
                     next
@@ -178,32 +180,32 @@ Dir.chdir(Autoproj::Packaging::OBS_BUILD_DIR) do
             end
 
             puts "packaging #{pkg_name} (#{i + 1}/#{selection.size})"
-            if File.file?(File.join(pkg.srcdir, "CMakeLists.txt"))
-                cmakelists_txt = File.read(File.join(pkg.srcdir, "CMakeLists.txt"))
+            if File.file?(File.join(pkginfo.srcdir, "CMakeLists.txt"))
+                cmakelists_txt = File.read(File.join(pkginfo.srcdir, "CMakeLists.txt"))
                 if cmakelists_txt =~ /include\(Rock\)|Rock\.cmake/ || cmakelists_txt =~ /find_package\(Rock\)/
-                    pkg.depends_on "base/cmake" unless pkg.name == "base/cmake"
+                    pkginfo.dependencies[:rock_pkginfo] <<
+                        package_info_ask.pkginfo_from_pkg(package_info_ask.package_by_name("base/cmake"))  unless pkginfo.name == "base/cmake"
                 end
             end
 
             begin
                 # just to update the required gem property
-                deps = packager.dependencies(pkg)
-                osdeps.concat deps[:osdeps]
-                selected_gems.concat deps[:extra_gems]
+                osdeps.concat pkginfo.dependencies[:osdeps]
+                selected_gems.concat pkginfo.dependencies[:extra_gems]
                 selected_gems.uniq!
 
-                packager.package(pkg, {:force_update => o_rebuild, :patch_dir => o_patch_dir, :existing_source_dir => o_src_dir, :package_set_dir => o_ps_dir })
+                packager.package(pkginfo, {:force_update => o_rebuild, :patch_dir => o_patch_dir, :existing_source_dir => o_src_dir, :package_set_dir => o_ps_dir })
 
-                if pkg.kind_of?(Autobuild::Ruby) &&
-                   pkg.name !~ /bundles/
+                if pkginfo.build_type == :ruby &&
+                   pkginfo.name !~ /bundles/
                     # register gem with the correct naming schema
                     # to make sure dependency naming and gem naming are consistent
-                    rock_ruby_gems << packager.debian_name(pkg)
+                    rock_ruby_gems << packager.debian_name(pkginfo)
                 end
             rescue Interrupt
                 raise
             rescue Exception => e
-                puts "failed to package #{pkg.name}: #{e.message} #{e.backtrace}"
+                puts "failed to package #{pkginfo.name}: #{e.message} #{e.backtrace}"
                 next
             end
         end
@@ -313,7 +315,8 @@ Dir.chdir(Autoproj::Packaging::OBS_BUILD_DIR) do
 
                 puts "OBS -- update pkg: #{pkg_name}"
                 # if the directory does not exist create one and add it to obs setup
-                pkg_obs_name = Autoproj::Packaging::Packager.obs_package_name(pkg)
+                pkginfo = package_info_ask.pkginfo_from_pkg(pkg)
+                pkg_obs_name = Autoproj::Packaging::Packager.obs_package_name(pkginfo)
                 Autoproj::Packaging::OBS.update_dir(o_obs_dir, Autoproj::Packaging::OBS_BUILD_DIR, pkg_obs_name, packager.file_suffix_patterns, o_commit)
             end
         end

--- a/bin/obs_package
+++ b/bin/obs_package
@@ -158,6 +158,10 @@ selection = selection.select do |pkg_name, i|
     end
 end
 
+selected_gems = Array.new()
+osdeps = Array.new()
+rock_ruby_gems = Array.new()
+
 Dir.chdir(Autoproj::Packaging::OBS_BUILD_DIR) do
 
     if o_all_packages
@@ -182,7 +186,20 @@ Dir.chdir(Autoproj::Packaging::OBS_BUILD_DIR) do
             end
 
             begin
+                # just to update the required gem property
+                deps = packager.dependencies(pkg)
+                osdeps.concat deps[:osdeps]
+                selected_gems.concat deps[:extra_gems]
+                selected_gems.uniq!
+
                 packager.package(pkg, {:force_update => o_rebuild, :patch_dir => o_patch_dir, :existing_source_dir => o_src_dir, :package_set_dir => o_ps_dir })
+
+                if pkg.kind_of?(Autobuild::Ruby) &&
+                   pkg.name !~ /bundles/
+                    # register gem with the correct naming schema
+                    # to make sure dependency naming and gem naming are consistent
+                    rock_ruby_gems << packager.debian_name(pkg)
+                end
             rescue Interrupt
                 raise
             rescue Exception => e
@@ -192,11 +209,13 @@ Dir.chdir(Autoproj::Packaging::OBS_BUILD_DIR) do
         end
     end
 
+    osdeps.uniq!
+
     # Check for osdeps -- fixed set of repositories at the moment
     if o_osdeps
         # Opendeps to process and check whether they and their dependencies are
         # available
-        openlist_osdeps = packager.osdeps
+        openlist_osdeps = osdeps
         Autoproj::Packaging.info "obs_package: checking osdeps: #{openlist_osdeps.join(",")}"
 
         # List of which osdeps which already have dealt with
@@ -216,12 +235,12 @@ Dir.chdir(Autoproj::Packaging::OBS_BUILD_DIR) do
                 next
             end
 
-            # Workaround,e.g., for nokogiri -- insert to ruby_gems list to force
+            # Workaround,e.g., for nokogiri -- insert to selected_gems list to force
             # gem2deb usage instead of using the default os package
             if override_osdeps.has_key?(osdeps_name)
                 type = override_osdeps[osdeps_name]
                 if  type == :gem
-                    packager.ruby_gems << osdeps_name.sub("ruby-","")
+                    selected_gems << osdeps_name.sub("ruby-","")
                 else
                     raise ArgumentError, "obs_package: unsupported osdeps override: #{type}"
                 end
@@ -276,7 +295,7 @@ Dir.chdir(Autoproj::Packaging::OBS_BUILD_DIR) do
 
     if o_extra_gem
         # Allow to build a gem explicitely
-        packager.ruby_gems << o_extra_gem
+        selected_gems << o_extra_gem
     end
 
     # Convert gems of which we know that need to be packaged -- needs to be set here, to include the osdeps overrides
@@ -300,7 +319,7 @@ Dir.chdir(Autoproj::Packaging::OBS_BUILD_DIR) do
         end
 
         # Update all gems
-        packager.ruby_gems.each do |gem_name, version|
+        selected_gems.each do |gem_name, version|
             if version
                 puts "OBS -- update gem: #{gem_name} with version #{version}"
             else
@@ -311,7 +330,7 @@ Dir.chdir(Autoproj::Packaging::OBS_BUILD_DIR) do
         end
 
         # Update rock gems
-        packager.ruby_rock_gems.each do |gem_name, version|
+        rock_ruby_gems.each do |gem_name, version|
             puts "OBS -- update rock gem (converted ruby package): #{gem_name}"
             pkg_obs_name = gem_name
             Autoproj::Packaging::OBS.update_dir(o_obs_dir, Autoproj::Packaging::OBS_BUILD_DIR, pkg_obs_name, packager.file_suffix_patterns, o_commit)

--- a/bin/obs_package
+++ b/bin/obs_package
@@ -113,7 +113,8 @@ class OBSConfiguration
     end
 end
 
-Autoproj::Packaging.root_dir = Autoproj.root_dir
+package_info_ask = Autoproj::Packaging::PackageInfoAsk.new(:detect, Hash.new())
+Autoproj::Packaging.root_dir = package_info_ask.root_dir
 
 obs_configuration = OBSConfiguration.new
 ################################################################################
@@ -138,12 +139,11 @@ if o_list_build_projects
     exit 0
 end
 
-root_dir  = Autoproj::CmdLine.initialize_root_directory
-selection = Autoproj::CmdLine.initialize_and_load(o_selected_packages)
-selection = Autoproj::CmdLine.resolve_user_selection(selection).packages
+selection = package_info_ask.autoproj_init_and_load(o_selected_packages)
+selection = package_info_ask.resolve_user_selection_packages(selection)
 
-packager = Autoproj::Packaging::Debian.new(File.join(Autoproj.root_dir, "debian"))
-package_info_ask = Autoproj::Packaging::PackageInfoAsk.new(:detect, Hash.new())
+Autoproj::Packaging::TargetPlatform.osdeps_release_tags= package_info_ask.osdeps_release_tags
+packager = Autoproj::Packaging::Debian.new(File.join(package_info_ask.root_dir, "debian"))
 
 packager.rock_autobuild_deps[:orogen] = [ package_info_ask.pkginfo_from_pkg(package_info_ask.package_by_name("orogen")) ]
 

--- a/bin/obs_package
+++ b/bin/obs_package
@@ -144,10 +144,6 @@ selection = Autoproj::CmdLine.resolve_user_selection(selection).packages
 
 packager = Autoproj::Packaging::Debian.new(File.join(Autoproj.root_dir, "debian"))
 
-packager.add_package_alias("tools/rtt","rtt")
-packager.add_package_alias("tools/rtt-typelib", "rtt-typelib")
-packager.add_package_alias("tools/typelib","typelib")
-
 packager.prepare
 
 # Make sure that when we request a package build we only get this one,

--- a/bin/obs_package
+++ b/bin/obs_package
@@ -112,6 +112,8 @@ class OBSConfiguration
     end
 end
 
+Autoproj::Packaging.root_dir = Autoproj.root_dir
+
 obs_configuration = OBSConfiguration.new
 ################################################################################
 

--- a/bin/obs_package
+++ b/bin/obs_package
@@ -1,5 +1,6 @@
 #! /usr/bin/env ruby
 require 'rock/packaging/debian'
+require 'rock/packaging/packageinfoask'
 
 o_skip_existing = false
 o_obs_dir = nil
@@ -143,6 +144,7 @@ selection = Autoproj::CmdLine.initialize_and_load(o_selected_packages)
 selection = Autoproj::CmdLine.resolve_user_selection(selection).packages
 
 packager = Autoproj::Packaging::Debian.new(File.join(Autoproj.root_dir, "debian"))
+package_info_ask = Autoproj::Packaging::PackageInfoAsk.new(:detect, Hash.new())
 
 packager.prepare
 

--- a/bin/obs_package
+++ b/bin/obs_package
@@ -197,7 +197,7 @@ Dir.chdir(Autoproj::Packaging::OBS_BUILD_DIR) do
         # Opendeps to process and check whether they and their dependencies are
         # available
         openlist_osdeps = packager.osdeps
-        Autoproj.info "obs_package: checking osdeps: #{openlist_osdeps.join(",")}"
+        Autoproj::Packaging.info "obs_package: checking osdeps: #{openlist_osdeps.join(",")}"
 
         # List of which osdeps which already have dealt with
         blacklist_osdeps = []
@@ -231,7 +231,7 @@ Dir.chdir(Autoproj::Packaging::OBS_BUILD_DIR) do
             # Check if the osdeps package is already available, otherwise add it
             # to the current obs project
             if not available_packages.include?(osdeps_name)
-                Autoproj.warn "OBS: Missing dependency: '#{osdeps_name}' --creating package dir in #{Autoproj::Packaging::OBS_BUILD_DIR}"
+                Autoproj::Packaging.warn "OBS: Missing dependency: '#{osdeps_name}' --creating package dir in #{Autoproj::Packaging::OBS_BUILD_DIR}"
                 if !File.directory?(Autoproj::Packaging::OBS_BUILD_DIR)
                     FileUtils.mkdir(Autoproj::Packaging::OBS_BUILD_DIR)
                 end
@@ -244,7 +244,7 @@ Dir.chdir(Autoproj::Packaging::OBS_BUILD_DIR) do
                     if system("obs_ubuntu_universe_package #{osdeps_name}")
                         update_osdeps << osdeps_name
                     else 
-                        Autoproj.warn "OBS: universe package for osdeps '#{osdeps_name}' could not be found"
+                        Autoproj::Packaging.warn "OBS: universe package for osdeps '#{osdeps_name}' could not be found"
                     end
                     blacklist_osdeps << osdeps_name
                     add_osdeps = Autoproj::Packaging::OBS.resolve_dependencies(osdeps_name)
@@ -267,7 +267,7 @@ Dir.chdir(Autoproj::Packaging::OBS_BUILD_DIR) do
                     if File.directory?(name)
                         Autoproj::Packaging::OBS.update_dir(obs_configuration.osdeps_target_directory(o_obs_dir),Autoproj::Packaging::OBS_BUILD_DIR, name, ["_service"], o_commit)
                     else
-                        Autoproj.warn "OBS: Requested update for #{name}, but directory does not exists in #{Autoproj::Packaging::OBS_BUILD_DIR}, i.e., the osdeps '#{name}' could not be resolved properly. Please check manually using 'obs_ubuntu_universe_package --validate #{name}'"
+                        Autoproj::Packaging.warn "OBS: Requested update for #{name}, but directory does not exists in #{Autoproj::Packaging::OBS_BUILD_DIR}, i.e., the osdeps '#{name}' could not be resolved properly. Please check manually using 'obs_ubuntu_universe_package --validate #{name}'"
                     end
                 end
             end

--- a/lib/rock/packaging.rb
+++ b/lib/rock/packaging.rb
@@ -1,6 +1,5 @@
 require_relative 'packaging/jenkins'
 require_relative 'packaging/config'
-require_relative 'packaging/gem_dependencies'
 require_relative 'packaging/obs'
 require_relative 'packaging/packager'
 require_relative 'packaging/target_platform'

--- a/lib/rock/packaging/autoproj1adaptor.rb
+++ b/lib/rock/packaging/autoproj1adaptor.rb
@@ -1,3 +1,6 @@
+require 'rexml/document'
+require 'autoproj'
+require 'autobuild'
 require 'rock/packaging/packageinfoask'
 
 module Autoproj
@@ -19,7 +22,372 @@ module Autoproj
             end
 
             def initialize(options)
+                # Package set order
+                @package_set_order = []
             end
+
+            private
+
+            # Extract the latest commit time for given importers
+            # return a Time object
+            def latest_commit_time(pkg)
+                importer = pkg.importer
+                if importer.kind_of?(Autobuild::Git)
+                    git_version(pkg)
+                elsif importer.kind_of?(Autobuild::SVN)
+                    svn_version(pkg)
+                elsif importer.kind_of?(Autobuild::ArchiveImporter) || importer.kind_of?(Autobuild::ImporterPackage)
+                    archive_version(pkg)
+                else
+                    Packager.warn "No version extraction yet implemented for importer type: #{importer.class} -- using current time for version string"
+                    Time.now
+                end
+            end
+
+            def git_version(pkg)
+                time_of_last_commit=pkg.importer.run_git_bare(pkg, 'log', '--encoding=UTF-8','--date=iso',"--pretty=format:'%cd'","-1").first
+                Time.parse(time_of_last_commit.strip)
+            end
+
+            def svn_version(pkg)
+                #["------------------------------------------------------------------------",
+                # "r21 | anauthor | 2012-10-01 13:46:46 +0200 (Mo, 01. Okt 2012) | 1 Zeile",
+                #  "",
+                #   "some comment",
+                #    "------------------------------------------------------------------------"]
+                #
+                svn_log = pkg.importer.run_svn(pkg, 'log', "-l 1", "--xml")
+                svn_log = REXML::Document.new(svn_log.join("\n"))
+                time_of_last_commit = nil
+                svn_log.elements.each('//log/logentry/date') do |d|
+                    time_of_last_commit = Time.parse(d.text)
+                end
+                time_of_last_commit
+            end
+
+            def archive_version(pkg)
+                File.lstat(pkg.importer.cachefile).mtime
+            end
+
+            public
+
+            def package_by_name(package_name)
+                Autoproj.manifest.package(package_name).autobuild
+            end
+
+            private
+
+            # Compute all packages that are require and their corresponding
+            # reverse dependencies
+            # return [Hash<package_name, reverse_dependencies>]
+            def reverse_dependencies(selection)
+                Packager.info ("#{selection.size} packages selected")
+                Packager.debug "Selection: #{selection}}"
+                orig_selection = selection.clone
+                reverse_dependencies = Hash.new
+
+                all_packages = Set.new
+                all_packages.merge(selection)
+                while true
+                    all_packages_refresh = all_packages.dup
+                    all_packages.each do |pkg_name|
+                        begin
+                            pkg_manifest = Autoproj.manifest.load_package_manifest(pkg_name)
+                        rescue Exception => e
+                            raise RuntimeError, "Autoproj::Packaging::Debian: failed to load manifest for '#{pkg_name}' -- #{e}"
+                        end
+
+                        pkg = pkg_manifest.package
+
+                        pkg.resolve_optional_dependencies
+                        reverse_dependencies[pkg.name] = pkg.dependencies.dup
+                        Packager.debug "deps: #{pkg.name} --> #{pkg.dependencies}"
+                        all_packages_refresh.merge(pkg.dependencies)
+                    end
+
+                    if all_packages.size == all_packages_refresh.size
+                        # nothing changed, so converged
+                        break
+                    else
+                        all_packages = all_packages_refresh
+                    end
+                end
+                Packager.info "all packages: #{all_packages.to_a}"
+                Packager.info "reverse deps: #{reverse_dependencies}"
+
+                reverse_dependencies
+            end
+
+            # Compute all required packages from a given selection
+            # including the dependencies
+            #
+            # The selection is a list of package names
+            #
+            # The order of the resulting package list is sorted
+            # accounting for interdependencies among packages
+            def all_required_rock_packages(selection)
+                reverse_dependencies = reverse_dependencies(selection)
+                sort_packages(reverse_dependencies)
+            end
+
+            def sort_packages(reverse_dependencies_hash)
+                # input is a hash, but we require a sorted list
+                # to deal with package set order, so we convert
+
+                reverse_dependencies = Array.new
+                if !package_set_order.empty?
+                    sorted_dependencies = Array.new
+                    sorted_pkgs = sort_by_package_sets(reverse_dependencies_hash.keys, package_set_order)
+                    sorted_pkgs.each do |pkg_name|
+                       pkg_dependencies = reverse_dependencies_hash[pkg_name]
+                       sorted_pkg_dependencies = sort_by_package_sets(pkg_dependencies, package_set_order)
+                       sorted_dependencies << [ pkg_name, sorted_pkg_dependencies ]
+                    end
+                    reverse_dependencies = sorted_dependencies
+                else
+                    reverse_dependencies_hash.each do |k,v|
+                        reverse_dependencies << [k,v]
+                    end
+                end
+
+                all_required_packages = Array.new
+                resolve_packages = []
+                while true
+                    if resolve_packages.empty?
+                        if reverse_dependencies.empty?
+                            break
+                        else
+                            # Pick the entries name
+                            resolve_packages = [ reverse_dependencies.first.first ]
+                        end
+                    end
+
+                    # Contains the name of all handled packages
+                    handled_packages = Array.new
+                    resolve_packages.each do |pkg_name|
+                        name, dependencies = reverse_dependencies.find { |p| p.first == pkg_name }
+                        if dependencies.empty?
+                            handled_packages << pkg_name
+                            pkg = Autoproj.manifest.package(pkg_name).autobuild
+                            all_required_packages << pkg
+                        else
+                            resolve_packages += dependencies
+                            resolve_packages.uniq!
+                        end
+                    end
+
+                    handled_packages.each do |pkg_name|
+                        resolve_packages.delete(pkg_name)
+                        reverse_dependencies.delete_if { |dep_name, _| dep_name == pkg_name }
+                    end
+
+                    reverse_dependencies.map! do |pkg,dependencies|
+                        dependencies.reject! { |x| handled_packages.include? x }
+                        [pkg, dependencies]
+                    end
+
+                    Packager.debug "Handled: #{handled_packages}"
+                    Packager.debug "Remaining: #{reverse_dependencies}"
+                    if handled_packages.empty? && !resolve_packages
+                        Packager.warn "Unhandled dependencies: #{resolve_packages}"
+                    end
+                end
+
+                all_required_packages
+            end
+
+            public
+
+            # Get all required packages that come with a given selection of packages
+            # including the dependencies of ruby gems
+            #
+            # This requires the current installation to be complete since
+            # `gem dependency <gem-name>` has been selected to provide the information
+            # of ruby dependencies
+            def all_required_packages(selection, selected_gems, with_rock_release_prefix = false)
+                all_packages = all_required_rock_packages(selection)
+
+                gems = Array.new
+                gem_versions = Hash.new
+
+                # Make sure to account for extra packages
+                selected_gems.each do |name, version|
+                    gems << name
+                    gem_versions[name] ||= Array.new
+                    gem_versions[name] << version
+                end
+
+                extra_gems = Array.new()
+                extra_osdeps = Array.new()
+
+                # Add the ruby requirements for the current rock selection
+                all_packages.each do |pkg|
+                    deps = dependencies(pkg, with_rock_release_prefix)
+                    # Update global list
+                    extra_osdeps.concat deps[:osdeps]
+                    extra_gems.concat deps[:extra_gems]
+
+                    deps = filtered_dependencies(pkg, dependencies(pkg, with_rock_release_prefix), with_rock_release_prefix)
+                    deps[:nonnative].each do |dep, version|
+                        gem_versions[dep] ||= Array.new
+                        if version
+                            gem_versions[dep] << version
+                        end
+                    end
+                end
+
+                gem_version_requirements = gem_versions.dup
+                gem_dependencies = GemDependencies.resolve_all(gem_versions)
+                gem_dependencies.each do |name, deps|
+                    if deps
+                        deps.each do |dep_name, dep_versions|
+                            gem_version_requirements[dep_name] ||= Array.new
+                            gem_version_requirements[dep_name] = (gem_version_requirements[dep_name] + dep_versions).uniq
+                        end
+                    end
+                end
+                exact_version_list = GemDependencies.gem_exact_versions(gem_version_requirements)
+                sorted_gem_list = GemDependencies.sort_by_dependency(gem_dependencies).uniq
+
+                {:packages => all_packages, :gems => sorted_gem_list, :gem_versions => exact_version_list, :extra_osdeps => extra_osdeps, :extra_gems => extra_gems }
+            end
+
+            private
+
+            # Compute dependencies of this package
+            # Returns [:rock => rock_packages, :osdeps => osdeps_packages, :nonnative => nonnative_packages ]
+            def dependencies(pkg, with_rock_release_prefix = true)
+                pkg = package_by_name(pkg.name)
+
+                pkg.resolve_optional_dependencies
+                deps_rock_pkgs = pkg.dependencies.map do |dep_name|
+                    package_by_name(dep_name)
+                end
+
+                pkg_osdeps = Autoproj.osdeps.resolve_os_dependencies(pkg.os_packages)
+                # There are limitations regarding handling packages with native dependencies
+                #
+                # Currently gems need to converted into debs using gem2deb
+                # These deps dependencies are updated here before uploading a package
+                #
+                # Generation of the debian packages from the gems can be done in postprocessing step
+                # i.e. see convert_gems
+
+                deps_osdeps_packages = []
+                native_package_manager = Autoproj.osdeps.os_package_handler
+                _, native_pkg_list = pkg_osdeps.find { |handler, _| handler == native_package_manager }
+
+                deps_osdeps_packages += native_pkg_list if native_pkg_list
+                Packager.info "'#{pkg.name}' with osdeps dependencies: '#{deps_osdeps_packages}'"
+
+                non_native_handlers = pkg_osdeps.collect do |handler, pkg_list|
+                    if handler != native_package_manager
+                        [handler, pkg_list]
+                    end
+                end.compact
+
+                non_native_dependencies = Set.new
+                extra_gems = Set.new
+                non_native_handlers.each do |pkg_handler, pkg_list|
+                    # Convert native ruby gems package names to rock-xxx
+                    if pkg_handler.kind_of?(Autoproj::PackageManagers::GemManager)
+                        pkg_list.each do |name,version|
+                            extra_gems << [name, version]
+                            non_native_dependencies << [name, version]
+                        end
+                    else
+                        raise ArgumentError, "cannot package #{pkg.name} as it has non-native dependencies (#{pkg_list}) -- #{pkg_handler.class} #{pkg_handler}"
+                    end
+                end
+                Packager.info "#{pkg.name}' with non native dependencies: #{non_native_dependencies.to_a}"
+
+                # Return rock packages, osdeps and non native deps (here gems)
+                {:rock_pkg => deps_rock_pkgs, :osdeps => deps_osdeps_packages, :nonnative => non_native_dependencies.to_a, :extra_gems => extra_gems.to_a }
+            end
+
+            def extra_configure_flags(package)
+                flags = []
+                key_value_regexp = Regexp.new(/([^=]+)=([^=]+)/)
+                package.configureflags.each do |flag|
+                    if match_data = key_value_regexp.match(flag)
+                        key = match_data[1]
+                        value = match_data[2]
+                        # Skip keys that start with --arguments
+                        # and assume defines starting with UpperCase
+                        # letter, e.g., CFLAGS='...'
+                        if key =~ /^[A-Z]/
+                            if value !~ /^["]/ && value !~ /^[']/
+                                value = "'#{match_data[2]}'"
+                            end
+                        end
+                        flags << "#{key}=#{value}"
+                    else
+                        flags << flag
+                    end
+                end
+                Packager.info "Using extra configure flags: #{flags}"
+                flags
+            end
+
+            # Sort by package set order
+            def sort_by_package_sets(packages, pkg_set_order)
+                priority_lists = Array.new
+                (0..pkg_set_order.size).each do |i|
+                    priority_lists << Array.new
+                end
+
+                packages.each do |package|
+                    if !package.kind_of?(String)
+                        package = package.name
+                    end
+                    pkg = Autoproj.manifest.package(package)
+                    pkg_set_name = pkg.package_set.name
+
+                    if index = pkg_set_order.index(pkg_set_name)
+                        priority_lists[index] << package
+                    else
+                        priority_lists.last << package
+                    end
+                end
+
+                priority_lists.flatten
+            end
+
+            # Import a package for packaging
+            def import_package(pkg, pkg_target_importdir)
+                # Some packages, e.g. mars use a single git repository a split it artificially
+                # if this is the case, try to copy the content instead of doing a proper checkout
+                if pkg.srcdir != pkg.importdir
+                    Packager.debug "Importing repository from #{pkg.srcdir} to #{pkg_target_importdir}"
+                    FileUtils.mkdir_p pkg_target_importdir
+                    FileUtils.cp_r File.join(pkg.srcdir,"/."), pkg_target_importdir
+                    # Update resulting source directory
+                    pkg.srcdir = pkg_target_importdir
+                else
+                    pkg.srcdir = pkg_target_importdir
+                    begin
+                        Packager.debug "Importing repository to #{pkg.srcdir}"
+                        # Workaround for bug in autoproj:
+                        # archive_dir should be set from pkg.srcdir, but is actually set from pkg.name
+                        # see autobuild-1.9.3/lib/autobuild/import/archive.rb +406
+                        if pkg.importer.kind_of?(Autobuild::ArchiveImporter)
+                            pkg.importer.options[:archive_dir] ||= File.basename(pkg.srcdir)
+                        end
+                        pkg.importer.import(pkg)
+                    rescue Exception => e
+                        if not e.message =~ /failed in patch phase/
+                            raise
+                        else
+                            Packager.warn "Patching #{pkg.name} failed"
+                        end
+                    end
+
+                    Dir.glob(File.join(pkg.srcdir, "*-stamp")) do |file|
+                        FileUtils.rm_f file
+                    end
+                end
+            end
+
         end #class Autoproj
     end #module Packaging
 end #module Autoproj

--- a/lib/rock/packaging/autoproj1adaptor.rb
+++ b/lib/rock/packaging/autoproj1adaptor.rb
@@ -62,18 +62,10 @@ module Autoproj
                 end
                 if pkg.importer.kind_of?(Autobuild::Git)
                     pkginfo.importer_type = :git
-                    pkginfo.importer_repository_id = pkg.importer.repository_id
-                    pkginfo.importer_current_branch = pkg.importer.current_branch(pkg)
-                    pkginfo.importer_common_commit = pkg.importer.status(pkg).common_commit
-                    pkginfo.importer_tag = pkg.importer.tag
                 elsif pkg.importer.kind_of?(Autobuild::SVN)
                     pkginfo.importer_type = :svn
-                    pkginfo.importer_repository_id = pkg.importer.repository_id
-                    pkginfo.importer_revision = pkg.importer.revision
                 elsif pkg.importer.kind_of?(Autobuild::ArchiveImporter)
                     pkginfo.importer_type = :archive_importer
-                    pkginfo.importer_url = pkg.importer.url
-                    pkginfo.importer_filename = pkg.importer.filename
                 end
                 if pkg.description.nil?
                     pkgi.description_version = "0"

--- a/lib/rock/packaging/autoproj1adaptor.rb
+++ b/lib/rock/packaging/autoproj1adaptor.rb
@@ -1,0 +1,26 @@
+require 'rock/packaging/packageinfoask'
+
+module Autoproj
+    module Packaging
+        class Autoproj1Adaptor < PackageInfoAsk
+
+            attr_accessor :package_set_order
+
+            def self.which
+                :autoproj_v1
+            end
+
+            def self.probe
+                #theoretically, we could check for every thing we use in
+                #autoproj, but this should suffice for now.
+                defined? Autoproj::CmdLine.initialize_root_directory()
+            rescue
+                false
+            end
+
+            def initialize(options)
+            end
+        end #class Autoproj
+    end #module Packaging
+end #module Autoproj
+

--- a/lib/rock/packaging/autoproj1adaptor.rb
+++ b/lib/rock/packaging/autoproj1adaptor.rb
@@ -26,6 +26,8 @@ module Autoproj
                 @package_set_order = []
 
                 @pkginfo_cache = {}
+
+                @pkg_manifest_cache = {}
             end
 
             def pkginfo_from_pkg(pkg)
@@ -156,8 +158,20 @@ module Autoproj
 
             public
 
+            def pkgmanifest_by_name(package_name)
+                if !@pkg_manifest_cache[package_name]
+                    begin
+                        puts "Loading manifest for #{package_name}"
+                        @pkg_manifest_cache[package_name] = Autoproj.manifest.package(package_name)
+                    rescue Exception => e
+                        raise RuntimeError, "Autoproj::Packaging::Autoproj1Adaptor: failed to load manifest for '#{package_name}' -- #{e}"
+                    end
+                end
+                @pkg_manifest_cache[package_name]
+            end
+            
             def package_by_name(package_name)
-                Autoproj.manifest.package(package_name).autobuild
+                pkgmanifest_by_name(package_name).autobuild
             end
 
             private

--- a/lib/rock/packaging/autoproj1adaptor.rb
+++ b/lib/rock/packaging/autoproj1adaptor.rb
@@ -39,7 +39,7 @@ module Autoproj
                 elsif importer.kind_of?(Autobuild::ArchiveImporter) || importer.kind_of?(Autobuild::ImporterPackage)
                     archive_version(pkg)
                 else
-                    Packager.warn "No version extraction yet implemented for importer type: #{importer.class} -- using current time for version string"
+                    Packaging.warn "No version extraction yet implemented for importer type: #{importer.class} -- using current time for version string"
                     Time.now
                 end
             end
@@ -81,8 +81,8 @@ module Autoproj
             # reverse dependencies
             # return [Hash<package_name, reverse_dependencies>]
             def reverse_dependencies(selection)
-                Packager.info ("#{selection.size} packages selected")
-                Packager.debug "Selection: #{selection}}"
+                Packaging.info ("#{selection.size} packages selected")
+                Packaging.debug "Selection: #{selection}}"
                 orig_selection = selection.clone
                 reverse_dependencies = Hash.new
 
@@ -101,7 +101,7 @@ module Autoproj
 
                         pkg.resolve_optional_dependencies
                         reverse_dependencies[pkg.name] = pkg.dependencies.dup
-                        Packager.debug "deps: #{pkg.name} --> #{pkg.dependencies}"
+                        Packaging.debug "deps: #{pkg.name} --> #{pkg.dependencies}"
                         all_packages_refresh.merge(pkg.dependencies)
                     end
 
@@ -112,8 +112,8 @@ module Autoproj
                         all_packages = all_packages_refresh
                     end
                 end
-                Packager.info "all packages: #{all_packages.to_a}"
-                Packager.info "reverse deps: #{reverse_dependencies}"
+                Packaging.info "all packages: #{all_packages.to_a}"
+                Packaging.info "reverse deps: #{reverse_dependencies}"
 
                 reverse_dependencies
             end
@@ -186,10 +186,10 @@ module Autoproj
                         [pkg, dependencies]
                     end
 
-                    Packager.debug "Handled: #{handled_packages}"
-                    Packager.debug "Remaining: #{reverse_dependencies}"
+                    Packaging.debug "Handled: #{handled_packages}"
+                    Packaging.debug "Remaining: #{reverse_dependencies}"
                     if handled_packages.empty? && !resolve_packages
-                        Packager.warn "Unhandled dependencies: #{resolve_packages}"
+                        Packaging.warn "Unhandled dependencies: #{resolve_packages}"
                     end
                 end
 
@@ -278,7 +278,7 @@ module Autoproj
                 _, native_pkg_list = pkg_osdeps.find { |handler, _| handler == native_package_manager }
 
                 deps_osdeps_packages += native_pkg_list if native_pkg_list
-                Packager.info "'#{pkg.name}' with osdeps dependencies: '#{deps_osdeps_packages}'"
+                Packaging.info "'#{pkg.name}' with osdeps dependencies: '#{deps_osdeps_packages}'"
 
                 non_native_handlers = pkg_osdeps.collect do |handler, pkg_list|
                     if handler != native_package_manager
@@ -299,7 +299,7 @@ module Autoproj
                         raise ArgumentError, "cannot package #{pkg.name} as it has non-native dependencies (#{pkg_list}) -- #{pkg_handler.class} #{pkg_handler}"
                     end
                 end
-                Packager.info "#{pkg.name}' with non native dependencies: #{non_native_dependencies.to_a}"
+                Packaging.info "#{pkg.name}' with non native dependencies: #{non_native_dependencies.to_a}"
 
                 # Return rock packages, osdeps and non native deps (here gems)
                 {:rock_pkg => deps_rock_pkgs, :osdeps => deps_osdeps_packages, :nonnative => non_native_dependencies.to_a, :extra_gems => extra_gems.to_a }
@@ -325,7 +325,7 @@ module Autoproj
                         flags << flag
                     end
                 end
-                Packager.info "Using extra configure flags: #{flags}"
+                Packaging.info "Using extra configure flags: #{flags}"
                 flags
             end
 
@@ -358,7 +358,7 @@ module Autoproj
                 # Some packages, e.g. mars use a single git repository a split it artificially
                 # if this is the case, try to copy the content instead of doing a proper checkout
                 if pkg.srcdir != pkg.importdir
-                    Packager.debug "Importing repository from #{pkg.srcdir} to #{pkg_target_importdir}"
+                    Packaging.debug "Importing repository from #{pkg.srcdir} to #{pkg_target_importdir}"
                     FileUtils.mkdir_p pkg_target_importdir
                     FileUtils.cp_r File.join(pkg.srcdir,"/."), pkg_target_importdir
                     # Update resulting source directory
@@ -366,7 +366,7 @@ module Autoproj
                 else
                     pkg.srcdir = pkg_target_importdir
                     begin
-                        Packager.debug "Importing repository to #{pkg.srcdir}"
+                        Packaging.debug "Importing repository to #{pkg.srcdir}"
                         # Workaround for bug in autoproj:
                         # archive_dir should be set from pkg.srcdir, but is actually set from pkg.name
                         # see autobuild-1.9.3/lib/autobuild/import/archive.rb +406
@@ -378,7 +378,7 @@ module Autoproj
                         if not e.message =~ /failed in patch phase/
                             raise
                         else
-                            Packager.warn "Patching #{pkg.name} failed"
+                            Packaging.warn "Patching #{pkg.name} failed"
                         end
                     end
 

--- a/lib/rock/packaging/autoproj1adaptor.rb
+++ b/lib/rock/packaging/autoproj1adaptor.rb
@@ -221,13 +221,13 @@ module Autoproj
                 extra_osdeps = Array.new()
 
                 # Add the ruby requirements for the current rock selection
+                #todo: this used to work an all_packages without the already installed packages
                 all_packages.each do |pkg|
                     deps = dependencies(pkg, with_rock_release_prefix)
                     # Update global list
                     extra_osdeps.concat deps[:osdeps]
                     extra_gems.concat deps[:extra_gems]
 
-                    deps = filtered_dependencies(pkg, dependencies(pkg, with_rock_release_prefix), with_rock_release_prefix)
                     deps[:nonnative].each do |dep, version|
                         gem_versions[dep] ||= Array.new
                         if version

--- a/lib/rock/packaging/config.rb
+++ b/lib/rock/packaging/config.rb
@@ -55,12 +55,6 @@ module Autoproj
         #    #armel: jessie
         #    #armhf: jessie
         #packages:
-        #    aliases:
-        #        tools/rtt: rtt
-        #        tools/rtt-typelib: rtt-typelib
-        #        tools/typelib: typelib
-        #        tools/utilrb: utilrb
-        #        tools/utilrb-ext: utilrb-ext
         #    optional: llvm,clang
         #    enforce_build: rgl
         #rock_releases:
@@ -82,7 +76,6 @@ module Autoproj
 
             attr_reader :architectures
 
-            attr_reader :packages_aliases
             attr_reader :packages_optional
             attr_reader :packages_enforce_build
 
@@ -125,7 +118,6 @@ module Autoproj
                 architectures.each do |arch,allowed_releases|
                     @architectures[arch] = allowed_releases.gsub(' ','').split(",")
                 end
-                @packages_aliases = configuration["packages"]["aliases"] || Hash.new
                 @packages_optional = configuration["packages"]["optional"] || ""
                 if @packages_optional
                     @packages_optional = @packages_optional.split(",")
@@ -178,10 +170,6 @@ module Autoproj
 
             def self.architectures
                 instance.architectures
-            end
-
-            def self.packages_aliases
-                instance.packages_aliases
             end
 
             def self.packages_optional
@@ -243,10 +231,6 @@ module Autoproj
                 end
                 s += "active linux distribution releases: #{active_distributions}\n"
                 s+= "packages:\n"
-                s += "    aliases:\n"
-                packages_aliases.each do |pkg_name, a|
-                    s += "        #{pkg_name} --> #{a}\n"
-                end
                 s += "    optional packages:\n"
                 packages_optional.each do |pkg_name|
                     s += "        #{pkg_name}\n"

--- a/lib/rock/packaging/debian.rb
+++ b/lib/rock/packaging/debian.rb
@@ -25,9 +25,6 @@ module Autoproj
             TEMPLATES_META = File.expand_path(File.join("templates", "debian-meta"), File.dirname(__FILE__))
             DEPWHITELIST = ["debhelper","gem2deb","ruby","ruby-rspec"]
 
-            # Package like tools/rtt etc. require a custom naming schema, i.e. the base name rtt should be used for tools/rtt
-            attr_reader :package_aliases
-
             attr_reader :existing_debian_directories
 
             # List of gems, which need to be converted to debian packages
@@ -66,7 +63,6 @@ module Autoproj
                 @ruby_gems = Array.new
                 @ruby_rock_gems = Array.new
                 @osdeps = Array.new
-                @package_aliases = Hash.new
                 @debian_version = Hash.new
                 @rock_base_install_directory = "/opt/rock"
 
@@ -106,11 +102,6 @@ module Autoproj
                 name
             end
 
-            # Add a package alias, e.g. for rtt --> tools/rtt
-            def add_package_alias(pkg_name, pkg_alias)
-                @package_aliases[pkg_name] = pkg_alias
-            end
-
             # The debian name of a package -- either
             # rock[-<release-name>]-<canonized-package-name>
             # or for ruby packages
@@ -123,10 +114,6 @@ module Autoproj
                     raise ArgumentError, "method debian_name expects a autobuild pkg as argument, got: #{pkg.class} '#{pkg}'"
                 end
                 name = pkg.name
-
-                if @package_aliases.has_key?(name)
-                    name = @package_aliases[name]
-                end
 
                 if pkg.kind_of?(Autobuild::Ruby)
                     debian_ruby_name(name, with_rock_release_prefix)
@@ -145,10 +132,6 @@ module Autoproj
             # with_rock_release_prefix to false
             #
             def debian_meta_name(name, with_rock_release_prefix = true)
-                if @package_aliases.has_key?(name)
-                    name = @package_aliases[name]
-                end
-
                 if with_rock_release_prefix
                     rock_release_prefix + canonize(name)
                 else
@@ -307,10 +290,6 @@ module Autoproj
                 while true
                     all_packages_refresh = all_packages.dup
                     all_packages.each do |pkg_name|
-                        if @package_aliases.has_key?(pkg_name)
-                            pkg_name = @package_aliases[pkg_name]
-                        end
-
                         begin
                             pkg_manifest = Autoproj.manifest.load_package_manifest(pkg_name)
                         rescue Exception => e

--- a/lib/rock/packaging/debian.rb
+++ b/lib/rock/packaging/debian.rb
@@ -1686,31 +1686,33 @@ module Autoproj
                         else
                             # Prefer metadata.yml over gemspec since it gives a more reliable timestamp
                             ['*.gemspec', 'metadata.yml'].each do |file|
-                                files = Dir.glob("#{gem_versioned_name}/#{file}")
-                                if not files.empty?
-                                    if files.first =~ /yml/
-                                        spec = YAML.load_file(files.first)
-                                    else
-                                        spec = Gem::Specification::load(files.first)
-                                    end
-                                else
-                                    Packager.info "Gem conversion: file #{file} does not exist"
-                                    next
-                                end
-
-                                #todo: not reliable. need sth better.
-                                if spec
-                                    if spec.date
-                                        if !tgz_date || spec.date < tgz_date
-                                            tgz_date = spec.date
-                                            Packager.info "#{file} has associated time: using #{tgz_date} as timestamp"
+                                Dir.chdir(gem_versioned_name) do
+                                    files = Dir.glob("#{file}")
+                                    if not files.empty?
+                                        if files.first =~ /yml/
+                                            spec = YAML.load_file(files.first)
+                                        else
+                                            spec = Gem::Specification::load(files.first)
                                         end
-                                        Packager.info "#{file} has associated time, but too recent, thus staying with #{tgz_date} as timestamp"
                                     else
-                                        Packager.warn "#{file} has no associated time: using current time for packaging"
+                                        Packager.info "Gem conversion: file #{file} does not exist"
+                                        next
                                     end
-                                else
-                                    Packager.warn "#{file} is not a spec file"
+
+                                    #todo: not reliable. need sth better.
+                                    if spec
+                                        if spec.date
+                                            if !tgz_date || spec.date < tgz_date
+                                                tgz_date = spec.date
+                                                Packager.info "#{files.first} has associated time: using #{tgz_date} as timestamp"
+                                            end
+                                            Packager.info "#{files.first} has associated time, but too recent, thus staying with #{tgz_date} as timestamp"
+                                        else
+                                            Packager.warn "#{files.first} has no associated time: using current time for packaging"
+                                        end
+                                    else
+                                        Packager.warn "#{files.first} is not a spec file"
+                                    end
                                 end
                             end
                         end

--- a/lib/rock/packaging/debian.rb
+++ b/lib/rock/packaging/debian.rb
@@ -1665,6 +1665,15 @@ module Autoproj
                         end
                         Packager.info "Converted: #{Dir.glob("**")}"
 
+                        # Check if patching is needed
+                        # To allow patching we need to split `gem2deb -S #{gem_name}`
+                        # into its substeps
+                        #
+                        Dir.chdir(gem_versioned_name) do
+                            package_name = options[:package_name] || gem_base_name
+                            patch_pkg_dir(package_name, options[:patch_dir], ["*.gemspec", "Rakefile", "metadata.yml"])
+                        end
+
                         # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=725348
                         checksums_file="checksums.yaml.gz"
                         files = Dir.glob("*/#{checksums_file}")

--- a/lib/rock/packaging/debian.rb
+++ b/lib/rock/packaging/debian.rb
@@ -224,9 +224,11 @@ module Autoproj
                 #
                 svn_log = pkg.importer.run_svn(pkg, 'log', "-l 1", "--xml")
                 svn_log = REXML::Document.new(svn_log.join("\n"))
+                time_of_last_commit = nil
                 svn_log.elements.each('//log/logentry/date') do |d|
                     time_of_last_commit = Time.parse(d.text)
                 end
+                time_of_last_commit
             end
 
             def archive_version(pkg)

--- a/lib/rock/packaging/debian.rb
+++ b/lib/rock/packaging/debian.rb
@@ -1770,7 +1770,7 @@ module Autoproj
                     end
 
                     debian_ruby_name = debian_ruby_name(gem_versioned_name)# + '~' + distribution
-                    debian_ruby_unversioned_name = debian_ruby_name.gsub(/-[0-9\.]*$/,"")
+                    debian_ruby_unversioned_name = debian_ruby_name.gsub(/-[0-9\.]*(\.rc[0-9]+)?$/,"")
                     Packager.info "Debian ruby name: #{debian_ruby_name} -- directory #{Dir.glob("**")}"
                     Packager.info "Debian ruby unversioned name: #{debian_ruby_unversioned_name}"
 

--- a/lib/rock/packaging/debian.rb
+++ b/lib/rock/packaging/debian.rb
@@ -560,7 +560,6 @@ module Autoproj
 
                 # Filter all packages that are available
                 if rock_release_name
-                    rock_release_platform = TargetPlatform.new(rock_release_name, target_platform.architecture)
                     sorted_gem_list = sorted_gem_list.select do |gem|
                         with_prefix = true
                         pkg_ruby_name = debian_ruby_name(gem, !with_prefix)

--- a/lib/rock/packaging/debian.rb
+++ b/lib/rock/packaging/debian.rb
@@ -1236,12 +1236,16 @@ module Autoproj
                 versioned_build_dir = plain_versioned_name(pkg, distribution)
                 deb_filename = "#{plain_versioned_name(pkg, FALSE)}_ARCHITECTURE.deb"
 
+                options[:parallel_build_level] = pkg.parallel_build_level
                 build_local(pkg_name, debian_name(pkg), versioned_build_dir, deb_filename, options)
             end
 
             # Build package locally
             # return path to locally build file
             def build_local(pkg_name, debian_pkg_name, versioned_build_dir, deb_filename, options)
+                options, unknown_options = Kernel.filter_options options,
+                    :distributions => nil,
+                    :parallel_build_level => nil
                 filepath = build_dir
                 distribution = max_one_distribution(options[:distributions])
                 # cd package_name
@@ -1294,10 +1298,9 @@ module Autoproj
 
                         FileUtils.mv 'debian', versioned_build_dir + '/'
                         FileUtils.chdir versioned_build_dir do
-                            pkg = Autoproj.manifest.packages[pkg_name]
                             cmd = "debuild -us -uc"
-                            if pkg && pkg.autobuild
-                                cmd += " -j#{pkg.autobuild.parallel_build_level}"
+                            if options[:parallel_build_level]
+                                cmd += " -j#{options[:parallel_build_level]}"
                             end
                             if !system(cmd)
                                 raise RuntimeError, "Packager: '#{cmd}' failed"

--- a/lib/rock/packaging/debian.rb
+++ b/lib/rock/packaging/debian.rb
@@ -1772,13 +1772,11 @@ module Autoproj
                     Packager.info "Debian ruby name: #{debian_ruby_name} -- directory #{Dir.glob("**")}"
                     Packager.info "Debian ruby unversioned name: #{debian_ruby_unversioned_name}"
 
-
                     # Check if patching is needed
                     # To allow patching we need to split `gem2deb -S #{gem_name}`
                     # into its substeps
                     #
                     Dir.chdir(debian_ruby_name) do
-
                         package_name = options[:package_name] || gem_base_name
                         if patch_pkg_dir(package_name, options[:patch_dir])
                             dpkg_commit_changes("deb_autopackaging_overlay")

--- a/lib/rock/packaging/debian.rb
+++ b/lib/rock/packaging/debian.rb
@@ -425,7 +425,7 @@ module Autoproj
                 end
 
                 pkg_name = nil
-                dependency_name = nil
+                dependency_debian_name = nil
                 is_osdep = nil
                 if pkg.is_a? String
                     # Handling of ruby and other gems
@@ -433,26 +433,26 @@ module Autoproj
                     release_name, is_osdep = native_dependency_name(pkg_name, selected_platform)
                     Packager.debug "Native dependency of ruby package: '#{pkg_name}' -- #{release_name}, is available as osdep: #{is_osdep}"
                     if is_osdep
-                        dependency_name = release_name
+                        dependency_debian_name = release_name
                     else
-                        dependency_name = debian_ruby_name(pkg_name)
+                        dependency_debian_name = debian_ruby_name(pkg_name)
                     end
                 else
                     pkg_name = pkg.name
                     # Handling of rock packages
-                    dependency_name = debian_name(pkg)
+                    dependency_debian_name = debian_name(pkg)
                 end
 
                 if !is_osdep
-                    if !reprepro_has_package?(dependency_name, rock_release_name,
-                                               selected_platform.distribution_release_name,
-                                               selected_platform.architecture)
+                    if !reprepro_has_package?(dependency_debian_name, rock_release_name,
+                                              selected_platform.distribution_release_name,
+                                              selected_platform.architecture)
 
-                        Packager.warn "Package #{dependency_name} is not available for #{selected_platform} in release #{rock_release_name} -- not added to osdeps file"
+                        Packager.warn "Package #{dependency_debian_name} is not available for #{selected_platform} in release #{rock_release_name} -- not added to osdeps file"
                         return
                     end
                 else
-                    Packager.info "Package #{dependency_name} will be provided through an osdep for #{selected_platform}"
+                    Packager.info "Package #{dependency_debian_name} will be provided through an osdep for #{selected_platform}"
                 end
 
                 # Get the operating system label
@@ -463,7 +463,7 @@ module Autoproj
                 Packager.debug "Existing definition: #{list[pkg_name]}"
                 pkg_definition = list[pkg_name] || Hash.new
                 distributions = pkg_definition[types_string] || Hash.new
-                distributions[labels_string] = dependency_name
+                distributions[labels_string] = dependency_debian_name
                 pkg_definition[types_string] = distributions
 
                 list[pkg_name] = pkg_definition

--- a/lib/rock/packaging/debian.rb
+++ b/lib/rock/packaging/debian.rb
@@ -97,9 +97,9 @@ module Autoproj
             # and the release-name can be avoided by setting
             # with_rock_release_prefix to false
             #
-            def debian_name_i(pkginfo, with_rock_release_prefix = true)
+            def debian_name(pkginfo, with_rock_release_prefix = true)
                 if pkginfo.kind_of?(String)
-                    raise ArgumentError, "method debian_name_i expects a PackageInfo as argument, got: #{pkginfo.class} '#{pkginfo}'"
+                    raise ArgumentError, "method debian_name expects a PackageInfo as argument, got: #{pkginfo.class} '#{pkginfo}'"
                 end
                 name = pkginfo.name
 
@@ -146,7 +146,7 @@ module Autoproj
                 end
             end
 
-            def debian_version_i(pkginfo, distribution, revision = "1")
+            def debian_version(pkginfo, distribution, revision = "1")
                 if !@debian_version.has_key?(pkginfo.name)
                     v = pkginfo.description_version
                     @debian_version[pkginfo.name] = v + "." + pkginfo.latest_commit_time.strftime("%Y%m%d") + "-" + revision
@@ -157,26 +157,26 @@ module Autoproj
                 @debian_version[pkginfo.name]
             end
 
-            def debian_plain_version_i(pkginfo)
+            def debian_plain_version(pkginfo)
                 pkginfo.description_version + "." + pkginfo.latest_commit_time.strftime("%Y%m%d")
             end
 
-            def versioned_name_i(pkginfo, distribution)
-                debian_name_i(pkginfo) + "_" + debian_version_i(pkginfo, distribution)
+            def versioned_name(pkginfo, distribution)
+                debian_name(pkginfo) + "_" + debian_version(pkginfo, distribution)
             end
 
-            def plain_versioned_name_i(pkginfo)
-                debian_name_i(pkginfo) + "_" + debian_plain_version_i(pkginfo)
+            def plain_versioned_name(pkginfo)
+                debian_name(pkginfo) + "_" + debian_plain_version(pkginfo)
             end
 
-            def plain_dir_name_i(pkginfo)
-                plain_versioned_name_i(pkginfo)
+            def plain_dir_name(pkginfo)
+                plain_versioned_name(pkginfo)
             end
 
-            def packaging_dir_i(pkginfo)
+            def packaging_dir(pkginfo)
                 pkg_name = pkginfo
                 if !pkginfo.kind_of?(String)
-                    pkg_name = debian_name_i(pkginfo)
+                    pkg_name = debian_name(pkginfo)
                 end
                 File.join(@build_dir, pkg_name, target_platform.to_s.gsub("/","-"))
             end
@@ -243,7 +243,7 @@ module Autoproj
                 else
                     pkg_name = pkginfo.name
                     # Handling of rock packages
-                    dependency_debian_name = debian_name_i(pkginfo)
+                    dependency_debian_name = debian_name(pkginfo)
                 end
 
                 if !is_osdep
@@ -297,7 +297,7 @@ module Autoproj
                 # Filter all packages that are available
                 if rock_release_name
                     all_pkginfos = all_pkginfos.select do |pkginfo|
-                        pkg_name = debian_name_i(pkginfo, true || with_prefix)
+                        pkg_name = debian_name(pkginfo, true || with_prefix)
                         !rock_release_platform.ancestorContains(pkg_name)
                     end
 
@@ -407,7 +407,7 @@ module Autoproj
                 end
 
                 deps_rock_packages = deps_rock_pkginfos.map do |pkginfo|
-                    debian_name = debian_name_i(pkginfo, with_rock_release_prefix)
+                    debian_name = debian_name(pkginfo, with_rock_release_prefix)
                     this_rock_release.packageReleaseName(debian_name)
                 end.sort
 
@@ -486,9 +486,9 @@ module Autoproj
 
                 FileUtils.mkdir_p dir
                 package_info = pkginfo
-                debian_name = debian_name_i(pkginfo)
-                debian_version = debian_version_i(pkginfo, distribution)
-                versioned_name = versioned_name_i(pkginfo, distribution)
+                debian_name = debian_name(pkginfo)
+                debian_version = debian_version(pkginfo, distribution)
+                versioned_name = versioned_name(pkginfo, distribution)
                 short_documentation = pkginfo.short_documentation
                 documentation = pkginfo.documentation
                 origin_information = pkginfo.origin_information
@@ -502,7 +502,7 @@ module Autoproj
                 dependencies = (deps_rock_packages + deps_osdeps_packages + deps_nonnative_packages).flatten
                 build_dependencies = dependencies.dup
                 @rock_autobuild_deps[pkginfo.build_type].each do |pkginfo|
-                    build_dependencies << debian_name_i( pkginfo )
+                    build_dependencies << debian_name( pkginfo )
                 end
                 if pkginfo.build_type == :cmake
                     build_dependencies << "cmake"
@@ -566,7 +566,7 @@ module Autoproj
                 if distribution
                   debian_version += '~' + distribution
                 end
-#                versioned_name = versioned_name_i(pkg, distribution)
+#                versioned_name = versioned_name(pkg, distribution)
 
                 with_rock_prefix = true
                 deps_rock_packages = depends
@@ -642,7 +642,7 @@ module Autoproj
                     :architecture => nil
 
                 if options[:force_update]
-                    dirname = packaging_dir_i(pkginfo)
+                    dirname = packaging_dir(pkginfo)
                     if File.directory?(dirname)
                         Packager.info "Debian: rebuild requested -- removing #{dirname}"
                         FileUtils.rm_rf(dirname)
@@ -651,7 +651,7 @@ module Autoproj
 
                 options[:distribution] ||= target_platform.distribution_release_name
                 options[:architecture] ||= target_platform.architecture
-                options[:packaging_dir] = packaging_dir_i(pkginfo)
+                options[:packaging_dir] = packaging_dir(pkginfo)
 
                 pkginfo = prepare_source_dir(pkginfo, options.merge(unknown_options))
 
@@ -684,7 +684,7 @@ module Autoproj
                 debian_pkg_name = debian_meta_name(name)
 
                 if options[:force_update]
-                    dirname = packaging_dir_i(debian_pkg_name)
+                    dirname = packaging_dir(debian_pkg_name)
                     if File.directory?(dirname)
                         Packager.info "Debian: rebuild requested -- removing #{dirname}"
                         FileUtils.rm_rf(dirname)
@@ -693,7 +693,7 @@ module Autoproj
 
                 options[:distribution] ||= target_platform.distribution_release_name
                 options[:architecture] ||= target_platform.architecture
-                pkg_dir = packaging_dir_i(debian_pkg_name)
+                pkg_dir = packaging_dir(debian_pkg_name)
                 options[:packaging_dir] = pkg_dir
 
                 if not File.directory?(pkg_dir)
@@ -769,8 +769,8 @@ module Autoproj
                             Packager.info "Debian: renaming #{gem} to #{gem_rename}"
                         end
 
-                        Packager.info "Debian: copy #{File.join(Dir.pwd, gem)} to #{packaging_dir_i(pkginfo)}"
-                        gem_final_path = File.join(packaging_dir_i(pkginfo), File.basename(gem_rename))
+                        Packager.info "Debian: copy #{File.join(Dir.pwd, gem)} to #{packaging_dir(pkginfo)}"
+                        gem_final_path = File.join(packaging_dir(pkginfo), File.basename(gem_rename))
                         FileUtils.cp gem, gem_final_path
 
                         # Prepare injection of dependencies through options
@@ -810,9 +810,9 @@ module Autoproj
 
                 distribution = options[:distribution]
 
-                Packager.info "Changing into packaging dir: #{packaging_dir_i(pkginfo)}"
-                Dir.chdir(packaging_dir_i(pkginfo)) do
-                    sources_name = plain_versioned_name_i(pkginfo)
+                Packager.info "Changing into packaging dir: #{packaging_dir(pkginfo)}"
+                Dir.chdir(packaging_dir(pkginfo)) do
+                    sources_name = plain_versioned_name(pkginfo)
                     # First, generate the source tarball
                     tarball = "#{sources_name}.orig.tar.gz"
 
@@ -841,9 +841,9 @@ module Autoproj
                             Packager.warn "Package: #{pkginfo.name} failed to perform dpkg-source -- #{Dir.entries(pkginfo.srcdir)}"
                             raise RuntimeError, "Debian: #{pkginfo.name} failed to perform dpkg-source in #{pkginfo.srcdir}"
                         end
-                        ["#{versioned_name_i(pkginfo, distribution)}.debian.tar.gz",
-                         "#{plain_versioned_name_i(pkginfo)}.orig.tar.gz",
-                         "#{versioned_name_i(pkginfo, distribution)}.dsc"]
+                        ["#{versioned_name(pkginfo, distribution)}.debian.tar.gz",
+                         "#{plain_versioned_name(pkginfo)}.orig.tar.gz",
+                         "#{versioned_name(pkginfo, distribution)}.dsc"]
                     else
                         Packager.info "Package: #{pkginfo.name} is up to date"
                     end
@@ -887,10 +887,10 @@ module Autoproj
                     :architecture => nil
                 distribution = options[:distribution]
 
-                Dir.chdir(packaging_dir_i(pkginfo)) do
+                Dir.chdir(packaging_dir(pkginfo)) do
 
-                    dir_name = plain_versioned_name_i(pkginfo)
-                    plain_dir_name = plain_versioned_name_i(pkginfo)
+                    dir_name = plain_versioned_name(pkginfo)
+                    plain_dir_name = plain_versioned_name(pkginfo)
                     FileUtils.rm_rf File.join(pkginfo.srcdir, "debian")
                     FileUtils.rm_rf File.join(pkginfo.srcdir, "build")
 
@@ -901,7 +901,7 @@ module Autoproj
                     cmake.close
 
                     # First, generate the source tarball
-                    sources_name = plain_versioned_name_i(pkginfo)
+                    sources_name = plain_versioned_name(pkginfo)
                     tarball = "#{plain_dir_name}.orig.tar.gz"
 
                     # Check first if actual source contains newer information than existing
@@ -929,9 +929,9 @@ module Autoproj
                             Packager.warn "Package: #{pkginfo.name} failed to perform dpkg-source: entries #{Dir.entries(pkginfo.srcdir)}"
                             raise RuntimeError, "Debian: #{pkginfo.name} failed to perform dpkg-source in #{pkginfo.srcdir}"
                         end
-                        ["#{versioned_name_i(pkginfo, distribution)}.debian.tar.gz",
-                         "#{plain_versioned_name_i(pkginfo)}.orig.tar.gz",
-                         "#{versioned_name_i(pkginfo, distribution)}.dsc"]
+                        ["#{versioned_name(pkginfo, distribution)}.debian.tar.gz",
+                         "#{plain_versioned_name(pkginfo)}.orig.tar.gz",
+                         "#{versioned_name(pkginfo, distribution)}.dsc"]
                     else
                         Packager.info "Package: #{pkginfo.name} is up to date"
                     end
@@ -963,11 +963,11 @@ module Autoproj
             def build_local_package(pkginfo, options)
                 #pkg_name is only used for progress messages
                 pkg_name = pkginfo.name
-                versioned_build_dir = plain_versioned_name_i(pkginfo)
-                deb_filename = "#{plain_versioned_name_i(pkginfo)}_ARCHITECTURE.deb"
+                versioned_build_dir = plain_versioned_name(pkginfo)
+                deb_filename = "#{plain_versioned_name(pkginfo)}_ARCHITECTURE.deb"
 
                 options[:parallel_build_level] = pkginfo.parallel_build_level
-                build_local(pkg_name, debian_name_i(pkginfo), versioned_build_dir, deb_filename, options)
+                build_local(pkg_name, debian_name(pkginfo), versioned_build_dir, deb_filename, options)
             end
 
             # Build package locally
@@ -1068,7 +1068,7 @@ module Autoproj
             # Install package
             def install(pkg_name, options)
                 begin
-                    pkg_build_dir = packaging_dir_i(pkg_name)
+                    pkg_build_dir = packaging_dir(pkg_name)
                     filepath = Dir.glob("#{pkg_build_dir}/*.deb")
                     if filepath.size < 1
                         raise RuntimeError, "No debian file found for #{pkg_name} in #{pkg_build_dir}: #{filepath}"
@@ -1107,12 +1107,12 @@ module Autoproj
             def package_updated?(pkginfo)
                 # Find an existing orig.tar.gz in the build directory
                 # ignoring the current version-timestamp
-                orig_file_name = Dir.glob("#{debian_name_i(pkginfo)}*.orig.tar.gz")
+                orig_file_name = Dir.glob("#{debian_name(pkginfo)}*.orig.tar.gz")
                 if orig_file_name.empty?
-                    Packager.info "No filename found for #{debian_name_i(pkginfo)} (existing files: #{Dir.entries('.')} -- package requires update (regeneration of orig.tar.gz)"
+                    Packager.info "No filename found for #{debian_name(pkginfo)} (existing files: #{Dir.entries('.')} -- package requires update (regeneration of orig.tar.gz)"
                     return true
                 elsif orig_file_name.size > 1
-                    Packager.warn "Multiple version of package #{debian_name_i(pkginfo)} in #{Dir.pwd} -- you have to fix this first"
+                    Packager.warn "Multiple version of package #{debian_name(pkginfo)} in #{Dir.pwd} -- you have to fix this first"
                 else
                     orig_file_name = orig_file_name.first
                 end
@@ -1186,7 +1186,7 @@ module Autoproj
                 gems.each do |gem_name, version|
                     gem_dir_name = debian_ruby_name(gem_name)
 
-                    packaging_dirname = packaging_dir_i(gem_dir_name)
+                    packaging_dirname = packaging_dir(gem_dir_name)
                     if options[:force_update]
                         if File.directory?(packaging_dirname)
                             Packager.info "Debian Gem: rebuild requested -- removing #{packaging_dirname}"
@@ -1551,7 +1551,7 @@ module Autoproj
                         end
 
                         options[:deps][:rock_pkginfo].each do |pkginfo|
-                            all_deps << debian_name_i(pkginfo)
+                            all_deps << debian_name(pkginfo)
                         end
 
                         # Add actual gem dependencies

--- a/lib/rock/packaging/gem_dependencies.rb
+++ b/lib/rock/packaging/gem_dependencies.rb
@@ -1,6 +1,7 @@
 require 'rubygems/requirement'
 require 'set'
 require 'autoproj'
+require 'rock/packaging/packager'
 
 module Autoproj
     module Packaging
@@ -27,7 +28,7 @@ module Autoproj
                 gem_dependency = `#{gem_dependency_cmd}`
 
                 if $?.exitstatus != 0
-                    Autoproj.warn "Failed to resolve #{gem_name} via #{gem_dependency_cmd} -- autoinstalling"
+                    Autoproj::Packaging.warn "Failed to resolve #{gem_name} via #{gem_dependency_cmd} -- autoinstalling"
                     gem_manager = ::Autoproj::PackageManagers::GemManager.new
                     if version_requirements.empty?
                         gem_manager.install([[gem_name]])
@@ -112,7 +113,7 @@ module Autoproj
             # Returns[Hash] with keys as required gems and versioned dependencies
             # as values (a Ruby Set)
             def self.resolve_all(gems)
-                Autoproj.info "Resolve all: #{gems}"
+                Autoproj::Packaging.info "Resolve all: #{gems}"
 
                 dependencies = Hash.new
                 handled_gems = Set.new
@@ -139,10 +140,10 @@ module Autoproj
                     remaining_gems = gems
                 end
 
-                Autoproj.info "Resolve remaining: #{remaining_gems}"
+                Autoproj::Packaging.info "Resolve remaining: #{remaining_gems}"
 
                 while !remaining_gems.empty?
-                    Autoproj.info "Resolve all: #{remaining_gems.to_a}"
+                    Autoproj::Packaging.info "Resolve all: #{remaining_gems.to_a}"
                     remaining = Hash.new
                     remaining_gems.each do |gem_name, gem_versions|
                         deps = resolve_by_name(gem_name, gem_versions)[:deps]
@@ -228,7 +229,7 @@ module Autoproj
             # uses 'gem fetch' for testing
             def self.is_gem?(gem_name)
                 if gem_name =~ /\//
-                    Autoproj.info "GemDependencies: invalid name -- cannot be a gem"
+                    Autoproj::Packaging.info "GemDependencies: invalid name -- cannot be a gem"
                     return false
                 end
                 # Check if this is a gem or not
@@ -240,7 +241,7 @@ module Autoproj
                         end
                     end
                     if !system("grep -ir ERROR #{outfile} > /dev/null 2>&1")
-                        Autoproj.info "GemDependencies: #{gem_name} is a ruby gem"
+                        Autoproj::Packaging.info "GemDependencies: #{gem_name} is a ruby gem"
                         return true
                     end
                 end

--- a/lib/rock/packaging/installer.rb
+++ b/lib/rock/packaging/installer.rb
@@ -246,7 +246,7 @@ module Autoproj
             end
 
             def self.pbuilder_hookdir(distribution, architecture, release_prefix)
-                base_hook_dir = File.join(Autoproj::Packaging::BUILD_DIR,"pbuilder-hookdir")
+                base_hook_dir = File.join(Autoproj::Packaging::build_dir,"pbuilder-hookdir")
                 hook_dir = File.join(base_hook_dir,"#{distribution}-#{architecture}-#{release_prefix}")
                 hook_dir
             end

--- a/lib/rock/packaging/jenkins.rb
+++ b/lib/rock/packaging/jenkins.rb
@@ -141,7 +141,7 @@ module Autoproj
                     debian_packager.rock_release_name = release_name
                 end
 
-                flow = debian_packager.all_required_packages(selection)
+                flow = debian_packager.filter_all_required_packages(debian_packager.all_required_packages(selection))
                 flow[:packages] = debian_packager.sort_by_package_sets(flow[:packages], options[:package_set_order])
                 flow[:gems].each do |name|
                     if !flow[:gem_versions].has_key?(name)

--- a/lib/rock/packaging/jenkins.rb
+++ b/lib/rock/packaging/jenkins.rb
@@ -180,7 +180,7 @@ module Autoproj
             def create_package_job(pkg, options = Hash.new)
                 with_rock_release_prefix = false
 
-                all_deps = debian_packager.dependencies(pkg)
+                all_deps = debian_packager.filtered_dependencies(pkg, debian_packager.dependencies(pkg))
                 Packager.info "Dependencies of #{pkg.name}: rock: #{all_deps[:rock]}, osdeps: #{all_deps[:osdeps]}, nonnative: #{all_deps[:nonnative].to_a}"
 
                 # Prepare upstream dependencies

--- a/lib/rock/packaging/jenkins.rb
+++ b/lib/rock/packaging/jenkins.rb
@@ -277,7 +277,7 @@ module Autoproj
             # there is no need to repackage the ruby package 'bundler' if it already
             # exists in a specific release of Ubuntu or Debian
             def combination_filter(architectures, distributions, package_name, isGem, options = Hash.new)
-                operating_system = Autoproj::OSDependencies.operating_system
+                operating_system = package_info_ask.operating_system
 
                 begin
                     Packager.info "Filter combinations of: archs #{architectures} , dists: #{distributions},
@@ -291,7 +291,7 @@ module Autoproj
                             target_platform = TargetPlatform.new(release, requested_architecture)
 
                             if Autoproj::Packaging::Config.linux_distribution_releases.has_key?(release)
-                                Autoproj::OSDependencies.operating_system = Autoproj::Packaging::Config.linux_distribution_releases[ release ]
+                                package_info_ask.operating_system = Autoproj::Packaging::Config.linux_distribution_releases[ release ]
                             else
                                 raise InvalidArgument, "Custom setting of operating system to: #{distribution} is not supported"
                             end
@@ -320,7 +320,7 @@ module Autoproj
                 rescue Exception => e
                     raise
                 ensure
-                    Autoproj::OSDependencies.operating_system = operating_system
+                    package_info_ask.operating_system = operating_system
                 end
 
                 ret = ""

--- a/lib/rock/packaging/packageinfo.rb
+++ b/lib/rock/packaging/packageinfo.rb
@@ -1,0 +1,7 @@
+
+module Autoproj
+    module Packaging
+        class PackageInfo
+        end #PackageInfo
+    end #Packaging
+end #Autoproj

--- a/lib/rock/packaging/packageinfo.rb
+++ b/lib/rock/packaging/packageinfo.rb
@@ -2,6 +2,67 @@
 module Autoproj
     module Packaging
         class PackageInfo
+            # rock name
+            attr_accessor :name
+            # time/date of latest change to the source package
+            attr_accessor :latest_commit_time
+            # version string
+            attr_accessor :description_version
+            # string containing the short documentation. newlines are
+            # allowed, but may be removed.
+            attr_accessor :short_documentation
+            # string containing the long documentation. newlines are
+            # allowed.
+            attr_accessor :documentation
+            # Array of strings appropriate as items in the changelog,
+            # describing the origin of the package, i.E. repository,
+            # revisions, source url etc.
+            attr_accessor :origin_information
+            # Number of parallel build processes
+            attr_accessor :parallel_build_level
+            # importer type, one of :git, :svn, :archive_importer
+            attr_accessor :importer_type
+            # build type, one of
+            # :orogen, :cmake, :autotools, :ruby, :archive_importer, :importer_package
+            attr_accessor :build_type
+            # directory containing the source ready to be packaged
+            attr_accessor :srcdir
+            #for build_type == :orogen
+            # orogen command invocation, only filled if build_type is :orogen
+            attr_accessor :orogen_command
+            #for build_type == :cmake or :orogen
+            # additional defines to be passed to cmake
+            attr_accessor :cmake_defines
+            #for build_type == :autotools
+            # if nonnil, libtool is used and contents are the executable to be
+            # used for libtool
+            attr_accessor :using_libtool
+            # if nonnil, autogen is used and contents are the executable to
+            # be used for autogen
+            attr_accessor :using_autogen
+            # additional configure flags to be passed to the build process
+            attr_accessor :extra_configure_flags
+            # imports the package to the importdir
+            # generally, that is a copy if a different source dir exists, but
+            # it may be a source control checkout.
+            def import(package_name)
+                raise "#{self.class} needs to overwrite import"
+            end
+
+            # raw dependencies
+            # can be processed with filtered_dependencies to obtain old
+            # behaviour
+            # [:rock_pkginfo => rock_pkginfos, :osdeps => osdeps_packages, :nonnative => nonnative_packages ]
+            def dependencies
+                raise "#{self.class} needs to overwrite dependencies"
+            end
+
+            # Array of PackageInfos, containing the packages that need to
+            # be build for this package. Mostly just this package and
+            # dependencies.
+            def required_rock_packages
+                raise "#{self.class} needs to overwrite required_rock_packages"
+            end
         end #PackageInfo
     end #Packaging
 end #Autoproj

--- a/lib/rock/packaging/packageinfoask.rb
+++ b/lib/rock/packaging/packageinfoask.rb
@@ -1,0 +1,58 @@
+
+module Autoproj
+    module Packaging
+        class PackageInfoAsk
+
+            class << self
+                alias :class_new :new
+
+                def new(which, options)
+                    if which == :detect
+                        subclasses.each do |subclass|
+                            if subclass.probe
+                                return subclass.new(options)
+                            end
+                        end
+                        raise "Cannot find a suitable packageinfo provider"
+                    end
+                    subclasses.each do |subclass|
+                        if which == subclass.which
+                            return subclass.new(options)
+                        end
+                    end
+                    raise "Don't know how to create an adaptor for #{which}"
+                end
+
+                def inherited(subclass)
+                    subclasses.add subclass
+                    # this allows child classes to use new as they are used to
+                    class << subclass
+                        alias :new :class_new
+                    end
+                end
+
+                def subclasses
+                    @subclasses ||= Set.new
+                end
+
+                def which
+                    raise "#{self} needs to overwrite self.which"
+                end
+
+                def probe
+                    # default implementation never auto probes
+                    false
+                end
+            end
+
+        end # class PackageInfoAsk
+    end # module Packaging
+end # module Autoproj
+
+begin
+    require 'rock/packaging/autoproj1adaptor'
+rescue LoadError
+    # in case the adaptors require fails, not so much that this require fails
+rescue
+    # if one of the backends does not load, we should still be fine.
+end

--- a/lib/rock/packaging/packageinfoask.rb
+++ b/lib/rock/packaging/packageinfoask.rb
@@ -45,6 +45,103 @@ module Autoproj
                 end
             end
 
+            def package_set_order
+                raise "#{self.class} needs to overwrite package_set_order"
+            end
+
+            def package_set_order=
+                raise "#{self.class} needs to overwrite package_set_order="
+            end
+
+            def osdeps_release_tags
+                raise "#{self.class} needs to overwrite osdeps_release_tags"
+            end
+
+            def osdeps_operating_system
+                raise "#{self.class} needs to overwrite osdeps_operating_system"
+            end
+
+            # required for jenkins.rb or if there is a specific operating
+            # system in the config file
+            def osdeps_operating_system= (os)
+                raise "#{self.class} needs to overwrite osdeps_operating_system="
+            end
+
+            def root_dir
+                raise "#{self.class} needs to overwrite root_dir"
+            end
+
+            def osdeps_set_alias(old_name, new_name)
+                raise "#{self.class} needs to overwrite osdeps_set_alias"
+            end
+
+            def autoproj_init_and_load(selection)
+                raise "#{self.class} needs to overwrite autoproj_init_and_load"
+            end
+
+            def resolve_user_selection_packages(selection)
+                raise "#{self.class} needs to overwrite resolve_user_selection_packages"
+            end
+
+            # returns an array of moved packages
+            def moved_packages
+                raise "#{self.class} needs to overwrite moved_packages"
+            end
+
+            # returns an autoproj package
+            def package(package_name)
+                raise "#{self.class} needs to overwrite package"
+            end
+
+            # returns true if pkgname is an autoproj meta package
+            def is_metapackage?(package_name)
+                raise "#{self.class} needs to overwrite is_metapackage?"
+            end
+
+            # returns true if pkgname is to be ignored
+            def ignored?(package_name)
+                raise "#{self.class} needs to overwrite ignored?"
+            end
+
+            # returns a PackageInfo from an autobuild package
+            def pkginfo_from_pkg(package)
+                raise "#{self.class} needs to overwrite pkginfo_from_pkg"
+            end
+
+            # returns an autobuild package from a package_name
+            def package_by_name(package_name)
+                raise "#{self.class} needs to overwrite package_by_name"
+            end
+
+            # Compute all required packages from a given selection
+            # including the dependencies
+            #
+            # The selection is a list of package names
+            #
+            # The order of the resulting package list is sorted
+            # accounting for interdependencies among packages
+            def all_required_rock_packages(selection)
+                raise "#{self.class} needs to overwrite all_required_rock_packages"
+            end
+
+            # Get all required packages that come with a given selection of packages
+            # including the dependencies of ruby gems
+            #
+            # This requires the current installation to be complete since
+            # `gem dependency <gem-name>` has been selected to provide the information
+            # of ruby dependencies
+            def all_required_packages(selection, with_rock_release_prefix = false)
+                raise "#{self.class} needs to overwrite all_required_packages"
+            end
+
+            # Sort by package set order
+            # can be used with any packages array of objects providing a name(),
+            # that is, works with both autobuild packages and PackageInfos
+            # returns a sorted array populated from elements of packages
+            def sort_by_package_sets(packages, pkg_set_order)
+                raise "#{self.class} needs to overwrite sort_by_package_sets"
+            end
+
         end # class PackageInfoAsk
     end # module Packaging
 end # module Autoproj

--- a/lib/rock/packaging/packager.rb
+++ b/lib/rock/packaging/packager.rb
@@ -1,6 +1,8 @@
 require 'autoproj'
 require 'autobuild'
 
+require 'utilrb/logger'
+
 module Autoproj
     module Packaging
         # Directory for temporary data to
@@ -15,6 +17,8 @@ module Autoproj
 
         EXCLUDED_DIRS_PREFIX = [".travis","build","tmp","debian",".autobuild",".orogen"]
         EXCLUDED_FILES_PREFIX = [".git",".travis",".orogen",".autobuild"]
+
+        extend Logger::Root("Packaging", Logger::INFO)
 
         class Packager
             extend Logger::Root("Packager", Logger::INFO)

--- a/lib/rock/packaging/packager.rb
+++ b/lib/rock/packaging/packager.rb
@@ -7,31 +7,43 @@ module Autoproj
     module Packaging
         # Directory for temporary data to
         # validate obs_packages
-        BUILD_DIR=File.join(Autoproj.root_dir, "build/rock-packager")
-        LOG_DIR=File.join(BUILD_DIR, "logs")
-        LOCAL_TMP = File.join(BUILD_DIR,".rock_packager")
         WWW_ROOT = File.join("/var/www")
         DEB_REPOSITORY=File.join(WWW_ROOT,"rock-reprepro")
         TEMPLATES_DIR=File.join(File.expand_path(File.dirname(__FILE__)),"templates")
-        CACHE_DIR=File.join(BUILD_DIR,"cache")
 
         EXCLUDED_DIRS_PREFIX = [".travis","build","tmp","debian",".autobuild",".orogen"]
         EXCLUDED_FILES_PREFIX = [".git",".travis",".orogen",".autobuild"]
 
         extend Logger::Root("Packaging", Logger::INFO)
 
+        def self.root_dir= (dir)
+            @root_dir = dir
+        end
+
+        def self.root_dir
+            @root_dir
+        end
+
+        def self.build_dir
+            File.join(root_dir, "build", "rock-packager")
+        end
+        
+        def self.cache_dir
+            File.join(build_dir, "cache")
+        end
+        
         class Packager
             extend Logger::Root("Packager", Logger::INFO)
 
-            attr_accessor :build_dir
-            attr_accessor :log_dir
-            attr_accessor :local_tmp_dir
-            attr_accessor :deb_repository
+            attr_reader :build_dir
+            attr_reader :log_dir
+            attr_reader :local_tmp_dir
+            attr_reader :deb_repository
 
             def initialize
-                @build_dir = BUILD_DIR
-                @log_dir = LOG_DIR
-                @local_tmp_dir = LOCAL_TMP
+                @build_dir = Autoproj::Packaging.build_dir
+                @log_dir = File.join(@build_dir, "logs")
+                @local_tmp_dir = File.join(@build_dir, ".rock_packager")
                 @deb_repository = DEB_REPOSITORY
             end
 

--- a/lib/rock/packaging/packager.rb
+++ b/lib/rock/packaging/packager.rb
@@ -10,7 +10,7 @@ module Autoproj
         LOCAL_TMP = File.join(BUILD_DIR,".rock_packager")
         WWW_ROOT = File.join("/var/www")
         DEB_REPOSITORY=File.join(WWW_ROOT,"rock-reprepro")
-        TEMPLATES_DIR=File.expand_path(File.dirname(__FILE__),"templates")
+        TEMPLATES_DIR=File.join(File.expand_path(File.dirname(__FILE__)),"templates")
         CACHE_DIR=File.join(BUILD_DIR,"cache")
 
         EXCLUDED_DIRS_PREFIX = [".travis","build","tmp","debian",".autobuild",".orogen"]

--- a/lib/rock/packaging/packager.rb
+++ b/lib/rock/packaging/packager.rb
@@ -239,41 +239,6 @@ module Autoproj
                 end
             end
 
-            # Import a package for packaging
-            def import_package(pkg, pkg_target_importdir)
-                # Some packages, e.g. mars use a single git repository a split it artificially
-                # if this is the case, try to copy the content instead of doing a proper checkout
-                if pkg.srcdir != pkg.importdir
-                    Packager.debug "Importing repository from #{pkg.srcdir} to #{pkg_target_importdir}"
-                    FileUtils.mkdir_p pkg_target_importdir
-                    FileUtils.cp_r File.join(pkg.srcdir,"/."), pkg_target_importdir
-                    # Update resulting source directory
-                    pkg.srcdir = pkg_target_importdir
-                else
-                    pkg.srcdir = pkg_target_importdir
-                    begin
-                        Packager.debug "Importing repository to #{pkg.srcdir}"
-                        # Workaround for bug in autoproj:
-                        # archive_dir should be set from pkg.srcdir, but is actually set from pkg.name
-                        # see autobuild-1.9.3/lib/autobuild/import/archive.rb +406
-                        if pkg.importer.kind_of?(Autobuild::ArchiveImporter)
-                            pkg.importer.options[:archive_dir] ||= File.basename(pkg.srcdir)
-                        end
-                        pkg.importer.import(pkg)
-                    rescue Exception => e
-                        if not e.message =~ /failed in patch phase/
-                            raise
-                        else
-                            Packager.warn "Patching #{pkg.name} failed"
-                        end
-                    end
-
-                    Dir.glob(File.join(pkg.srcdir, "*-stamp")) do |file|
-                        FileUtils.rm_f file
-                    end
-                end
-            end
-
             # Prepare source directory and provide and pkg with update importer
             # information
             # return Autobuild package with update importer definition

--- a/lib/rock/packaging/packager.rb
+++ b/lib/rock/packaging/packager.rb
@@ -227,7 +227,7 @@ module Autoproj
 
             # Import from a local src directory into the packaging directory for the debian packaging
             def import_from_local_src_dir(pkginfo, local_src_dir, packaging_dir)
-                pkg_target_importdir = File.join(packaging_dir, plain_dir_name_i(pkginfo))
+                pkg_target_importdir = File.join(packaging_dir, plain_dir_name(pkginfo))
                 Packager.info "Preparing source dir #{pkginfo.name} from existing: '#{local_src_dir}' -- import into: #{pkg_target_importdir}"
                 if !pkginfo.importer_type || !pkginfo.importer_type == :git
                     Packager.info "Package importer requires copying into target directory"
@@ -248,7 +248,7 @@ module Autoproj
 
                 options, unknown_options = Kernel.filter_options options,
                     :existing_source_dir => nil,
-                    :packaging_dir => File.join(@build_dir, debian_name_i(pkginfo))
+                    :packaging_dir => File.join(@build_dir, debian_name(pkginfo))
 
                 pkg_dir = options[:packaging_dir]
                 if not File.directory?(pkg_dir)
@@ -271,7 +271,7 @@ module Autoproj
                 if support_local_import && existing_source_dir = options[:existing_source_dir]
                     import_from_local_src_dir(pkginfo, existing_source_dir, pkg_dir)
                 else
-                    pkg_target_importdir = File.join(pkg_dir, plain_dir_name_i(pkginfo))
+                    pkg_target_importdir = File.join(pkg_dir, plain_dir_name(pkginfo))
                     pkginfo.import(pkg_target_importdir)
                 end
                 pkginfo

--- a/lib/rock/packaging/packager.rb
+++ b/lib/rock/packaging/packager.rb
@@ -229,7 +229,7 @@ module Autoproj
 
             # Import from a local src directory into the packaging directory for the debian packaging
             def import_from_local_src_dir(pkg, local_src_dir, packaging_dir)
-                pkg_target_importdir = File.join(packaging_dir, plain_dir_name(pkg, target_platform.distribution_release_name))
+                pkg_target_importdir = File.join(packaging_dir, plain_dir_name(pkg))
                 Packager.info "Preparing source dir #{pkg.name} from existing: '#{local_src_dir}' -- import into: #{pkg_target_importdir}"
                 if !pkg.importer || !pkg.importer.kind_of?(Autobuild::Git)
                    Packager.info "Package importer requires coping into target directory"
@@ -344,7 +344,7 @@ module Autoproj
                         end
                         pkg.importer.repository = pkg.srcdir
                     end
-                    pkg_target_importdir = File.join(pkg_dir, plain_dir_name(pkg, target_platform.distribution_release_name))
+                    pkg_target_importdir = File.join(pkg_dir, plain_dir_name(pkg))
 
                     import_package(pkg, pkg_target_importdir)
                 end

--- a/lib/rock/packaging/target_platform.rb
+++ b/lib/rock/packaging/target_platform.rb
@@ -47,13 +47,20 @@ module Autoproj
                                    autodetect_dpkg_architecture)
             end
 
+            def self.osdeps_release_tags
+                @osdeps_release_tags
+            end
+
+            def self.osdeps_release_tags= (tags)
+                @osdeps_release_tags = tags
+            end
+            
             # Autodetect the linux distribution release
             # require the general allow identification tag to be present in the
             # configuration file
             def self.autodetect_linux_distribution_release
-                distribution,release_tags = Autoproj::OSDependencies.operating_system
                 release = nil
-                release_tags.each do |tag|
+                osdeps_release_tags.each do |tag|
                     if Config.linux_distribution_releases.include?(tag)
                         return tag
                     end

--- a/lib/rock/packaging/target_platform.rb
+++ b/lib/rock/packaging/target_platform.rb
@@ -125,7 +125,7 @@ module Autoproj
                     if platform.contains(package_name)
                         return ancestor_release_name
                     else
-                        Packager.info "#{self} ancestor #{platform} does not contain #{package_name}"
+                        Autoproj::Packaging::info "#{self} ancestor #{platform} does not contain #{package_name}"
                     end
                 end
                 return ""
@@ -159,7 +159,7 @@ module Autoproj
                 outfile = cacheFilename(package, distribution_release_name, architecture)
                 if !File.exists?(outfile)
                     cmd = "dcontrol #{package}@#{architecture}/#{distribution_release_name} > #{outfile} 2> #{outfile}"
-                    Packager.info "TargetPlatform::debianContains: #{cmd}"
+                    Autoproj::Packaging.info "TargetPlatform::debianContains: #{cmd}"
                     if !system(cmd)
                         return false
                     end
@@ -179,7 +179,7 @@ module Autoproj
             def contains(package, cache_results = true)
                 # handle corner cases, e.g. rgl
                 if Packaging::Config.packages_enforce_build.include?(package)
-                    Packager.info "Distribution::contains returns false -- since configuration set to forced manual build #{package}"
+                    Autoproj::Packaging.info "Distribution::contains returns false -- since configuration set to forced manual build #{package}"
                     return false
                 end
                 release_name = distribution_release_name
@@ -193,7 +193,7 @@ module Autoproj
                     begin
                         return debianContains(package, true)
                     rescue Exception => e
-                        Packager.warn "#{e} -- falling back to http query-based package verification"
+                        Autoproj::Packaging.warn "#{e} -- falling back to http query-based package verification"
                         urls << File.join(debian,release_name,architecture,package,"download")
                     end
                 elsif TargetPlatform::isRock(release_name)
@@ -221,7 +221,7 @@ module Autoproj
                         # query already done sometime before
                     else
                         cmd = "wget -O #{outfile} -o #{errorfile} #{url}"
-                        Packager.info "TargetPlatform::contains: query with #{cmd}"
+                        Autoproj::Packaging.info "TargetPlatform::contains: query with #{cmd}"
                         system(cmd)
                     end
 
@@ -259,16 +259,16 @@ module Autoproj
                                 # allow all users to read and write file
                                 FileUtils.chmod 0666, file
                             rescue
-                                Packager.info "TargetPlatform::contains could not change permissions for #{file}"
+                                Autoproj::Packaging.info "TargetPlatform::contains could not change permissions for #{file}"
                             end
                         end
                     end
                 end
 
                 if result
-                    Packager.info "TargetPlatform #{to_s} contains #{package}"
+                    Autoproj::Packaging.info "TargetPlatform #{to_s} contains #{package}"
                 else
-                    Packager.info "TargetPlatform #{to_s} does not contain #{package}"
+                    Autoproj::Packaging.info "TargetPlatform #{to_s} does not contain #{package}"
                 end
                 result
             end

--- a/lib/rock/packaging/target_platform.rb
+++ b/lib/rock/packaging/target_platform.rb
@@ -140,7 +140,7 @@ module Autoproj
             end
 
             def cacheFilename(package, release_name, architecture)
-                File.join(Autoproj::Packaging::CACHE_DIR,"deb_package-availability-#{package}-in-#{release_name}-#{architecture}")
+                File.join(Autoproj::Packaging.cache_dir,"deb_package-availability-#{package}-in-#{release_name}-#{architecture}")
             end
 
             # Use dcontrol in order to check if the debian distribution contains
@@ -153,8 +153,8 @@ module Autoproj
                     raise RuntimeError, "TargetPlatform::debianContains: requires 'devscripts' to be installed for dcontrol"
                 end
 
-                if !File.exist?(Autoproj::Packaging::CACHE_DIR)
-                    FileUtils.mkdir_p Autoproj::Packaging::CACHE_DIR
+                if !File.exist?(Autoproj::Packaging.cache_dir)
+                    FileUtils.mkdir_p Autoproj::Packaging.cache_dir
                 end
                 outfile = cacheFilename(package, distribution_release_name, architecture)
                 if !File.exists?(outfile)
@@ -206,8 +206,8 @@ module Autoproj
                 errorfile = nil
                 result = true
 
-                if !File.exist?(Autoproj::Packaging::CACHE_DIR)
-                    FileUtils.mkdir_p Autoproj::Packaging::CACHE_DIR
+                if !File.exist?(Autoproj::Packaging.cache_dir)
+                    FileUtils.mkdir_p Autoproj::Packaging.cache_dir
                 end
 
                 urls.each do |url|

--- a/lib/rock/packaging/templates/debian-meta/changelog
+++ b/lib/rock/packaging/templates/debian-meta/changelog
@@ -1,23 +1,5 @@
 <%= debian_name %> (<%= debian_version %>) unstable; urgency=low
 
   * Package automatically built using autoproj-package debian
-<%begin%>
-<%if pkg.importer.kind_of?(Autobuild::Git) %>
-<% status = pkg.importer.status(pkg) %>
-   * repository: <%= pkg.importer.repository_id %>
-   * branch: <%= pkg.importer.current_branch(pkg) %>
-   * commit: <%= status.common_commit %>
-   * tag: <%= pkg.importer.tag %>
-<%elsif pkg.importer.kind_of?(Autobuild::SVN) %>
-   * repository: <%= pkg.importer.repository_id %>
-   * revision: <%= pkg.importer.revision %>
-<%elsif pkg.importer.kind_of?(Autobuild::ArchiveImporter) %>
-    * url: <%= pkg.importer.url %>
-    * filename: <%= pkg.importer.filename %>
-<%end%>
-<%rescue Exception => e%>
-    * the repository and commit information could not be extracted
-      * error at generation: <%= e.to_s %>
-<%end%>
 
  -- Packaging Daemon <rock-dev@dfki.de>  <%= Time.now.strftime("%a, %d %b %Y %H:%M:%S %z") %>

--- a/lib/rock/packaging/templates/debian/changelog
+++ b/lib/rock/packaging/templates/debian/changelog
@@ -1,23 +1,8 @@
 <%= debian_name %> (<%= debian_version %>) unstable; urgency=low
 
   * Package automatically built using autoproj-package debian
-<%begin%>
-<%if package.importer.kind_of?(Autobuild::Git) %>
-<% status = package.importer.status(package) %>
-   * repository: <%= package.importer.repository_id %>
-   * branch: <%= package.importer.current_branch(package) %>
-   * commit: <%= status.common_commit %>
-   * tag: <%= package.importer.tag %>
-<%elsif package.importer.kind_of?(Autobuild::SVN) %>
-   * repository: <%= package.importer.repository_id %>
-   * revision: <%= package.importer.revision %>
-<%elsif package.importer.kind_of?(Autobuild::ArchiveImporter) %>
-    * url: <%= package.importer.url %>
-    * filename: <%= package.importer.filename %>
-<%end%>
-<%rescue Exception => e%>
-    * the repository and commit information could not be extracted
-      * error at generation: <%= e.to_s %>
-<%end%>
+<% origin_information.each do |line| %>
+  * <%= line %>
+<% end %>
 
  -- Packaging Daemon <rock-dev@dfki.de>  <%= Time.now.strftime("%a, %d %b %Y %H:%M:%S %z") %>

--- a/lib/rock/packaging/templates/debian/control
+++ b/lib/rock/packaging/templates/debian/control
@@ -2,32 +2,6 @@ Source: <%= debian_name %>
 Section: science
 Priority: extra
 Maintainer: Rock Packaging Daemon <rock-dev@dfki.de>
-% dependencies = (deps_rock_packages + deps_osdeps_packages + deps_nonnative_packages).flatten
-% build_dependencies = dependencies.dup
-% if package.class == Autobuild::CMake
-%     build_dependencies << "cmake"
-% elsif package.class == Autobuild::Orogen
-%     build_dependencies << "cmake"
-%     build_dependencies << debian_name( package_by_name("orogen") )
-% elsif package.class == Autobuild::Autotools
-%     if package.using[:libtool]
-%         build_dependencies << "libtool"
-%     end
-%     build_dependencies << "autotools-dev" # as autotools seems to be virtual...
-%     build_dependencies << "autoconf"
-%     build_dependencies << "automake"
-%     build_dependencies << "dh-autoreconf"
-% elsif package.kind_of?(Autobuild::Ruby)
-%     if package.name =~ /bundles/
-%         build_dependencies << "cmake"
-%     else
-%         raise "debian/control: cannot handle ruby package"
-%     end
-% elsif package.importer.kind_of?(Autobuild::ArchiveImporter) || package.kind_of?(Autobuild::ImporterPackage)
-%     build_dependencies << "cmake"
-% else
-%     raise "debian/control: cannot handle package type #{package.class} for #{package.name}"
-% end
 Build-Depends: cdbs, debhelper (>= 8.0.0), pkg-config, dh-autoreconf, <%= build_dependencies.uniq.sort.join(", ") %>
 Standards-Version: 3.9.2
 Homepage: http://rock-robotics.org
@@ -42,13 +16,13 @@ Depends: ${shlibs:Depends}
 <% else %>
 Depends: ${shlibs:Depends}, <%= runtime_dependencies.join(", ") %>
 <% end %>
-Description: <%= package.description.short_documentation.split("\n").join(" ").strip %>
-% documentation = package.description.documentation.split("\n").map do |l|
+Description: <%= short_documentation.split("\n").join(" ").strip %>
+% docs = documentation.split("\n").map do |l|
 %      l = l.strip
 %      if l.empty?
 %        l = "."
 %      end
 %      l
 %    end.join("\n  ")
- <%= documentation %>
+ <%= docs %>
 

--- a/lib/rock/packaging/templates/debian/postinst
+++ b/lib/rock/packaging/templates/debian/postinst
@@ -8,6 +8,8 @@ my $rock_install_dir = "<%= rock_install_directory %>";
 my $rock_doc_install_dir = "$rock_install_dir/share/doc";
 
 sub update_index_html() {
+    #make sure $rock_doc_install_dir exists
+    system("mkdir","-p",$rock_doc_install_dir);
     #collect candidate files
     my @dirs = glob("$rock_doc_install_dir/*/");
     my @indexes = map {

--- a/lib/rock/packaging/templates/debian/rules
+++ b/lib/rock/packaging/templates/debian/rules
@@ -35,7 +35,7 @@ pre-build::
 <% if package.class == Autobuild::Orogen %>
 	# Making sure orogen is executed before cmake is called
 	echo "pre-build: calling orogen in order to generate CMake layout"
-	$(env_setup) orogen <%= Autobuild::Orogen.orogen_options.join(" ") %> <%= package.orogen_options.join(" ") %> --corba --transports=corba,mqueue,typelib --type-export-policy=used <%= package.orogen_file %>
+	$(env_setup) <%= orogen_command %>
 	#echo "Current directory including oroGen generated files"
 	#find . 
 <% end %>

--- a/lib/rock/packaging/templates/debian/rules
+++ b/lib/rock/packaging/templates/debian/rules
@@ -32,7 +32,7 @@ pre-build::
 ######################################
 # BEGIN OROGEN -- This block needs to be executed before CMAKE
 
-<% if package.class == Autobuild::Orogen %>
+<% if package_info.build_type == :orogen %>
 	# Making sure orogen is executed before cmake is called
 	echo "pre-build: calling orogen in order to generate CMake layout"
 	$(env_setup) <%= orogen_command %>
@@ -44,7 +44,7 @@ pre-build::
 ######################################
 # BEGIN CMAKE
 #
-<% if package.class == Autobuild::CMake || package.class == Autobuild::Orogen %>
+<% if package_info.build_type == :cmake || package_info.build_type == :orogen %>
 # Defining the cmake command and setting the required enviroment variables
 # PKG_CONFIG_PATH Resolve Rock package via pkg-config
 # Rock_DIR Set to make sure find_package(Rock) does work
@@ -58,7 +58,7 @@ DEB_CMAKE_EXTRA_FLAGS = -DCMAKE_SKIP_RPATH=OFF
 # Telling FindGEM.cmake to search for os packages using pkg-config and not for gems
 DEB_CMAKE_EXTRA_FLAGS += -DGEM_OS_PKG=TRUE
 # Leaving RUBY_EXECUTABLE unset since it maps to a path of the user executing the upload script
-DEB_CMAKE_EXTRA_FLAGS += <%= package.defines.map { |k, v| "-D#{k}=\"#{v}\"" unless "#{k}" == "RUBY_EXECUTABLE" || "#{k}" == "ROCK_TEST_ENABLED" || "#{k}" == "ROCK_TEST_LOG_DIR" }.join(" ") %>
+DEB_CMAKE_EXTRA_FLAGS += <%= package_info.cmake_defines.map { |k, v| "-D#{k}=\"#{v}\"" unless "#{k}" == "RUBY_EXECUTABLE" || "#{k}" == "ROCK_TEST_ENABLED" || "#{k}" == "ROCK_TEST_LOG_DIR" }.join(" ") %>
 # Disable ROCK Testing -- since running test on the OBS would require proper setting of path, etc. (see. data_processing/type_to_vector)
 DEB_CMAKE_EXTRA_FLAGS += -DROCK_TEST_ENABLED=OFF -UROCK_TEST_LOG_DIR
 include /usr/share/cdbs/1/class/cmake.mk
@@ -67,17 +67,17 @@ include /usr/share/cdbs/1/class/cmake.mk
 ##########################################
 # BEGIN AUTOTOOLS
 #
-<% elsif package.class == Autobuild::Autotools %>
+<% elsif package_info.build_type == :autotools %>
 DEB_CONFIGURE_PREFIX= $(rock_install_dir)
-DEB_CONFIGURE_EXTRA_FLAGS = <%= extra_configure_flags(package).join(" ") %>
+DEB_CONFIGURE_EXTRA_FLAGS = <%= package_info.extra_configure_flags.join(" ") %>
 
 # use autoreconf: check with external/libply
 # use autogen: check with drivers/araviz
-<% if package.using[:autogen].nil? %>
-<%     package.using[:autogen] = %w{autogen autogen.sh}.find { |f| File.exist?(File.join(package.srcdir, f)) } %>
+<% if package_info.using_autogen.nil? %>
+<%     package_info.using_autogen = %w{autogen autogen.sh}.find { |f| File.exist?(File.join(package_info.srcdir, f)) } %>
 <% end %>
-<% if package.using[:autogen] %>
-DEB_DH_AUTORECONF_ARGS += <%= File.join(".",package.using[:autogen]) %>
+<% if package_info.using_autogen %>
+DEB_DH_AUTORECONF_ARGS += <%= File.join(".",package_info.using_autogen) %>
 <% end %>
 include /usr/share/cdbs/1/class/autotools.mk
 include /usr/share/cdbs/1/rules/autoreconf.mk
@@ -86,7 +86,7 @@ include /usr/share/cdbs/1/rules/autoreconf.mk
 ############################################
 # BEGIN IMPORTER
 #
-<% elsif package.importer.kind_of?(Autobuild::ArchiveImporter) || package.kind_of?(Autobuild::ImporterPackage) || package_info.name =~ /bundles/ %>
+<% elsif package_info.importer_type == :archive_importer || package_info.build_type == :importer_package || package_info.name =~ /bundles/ %>
 CMAKE = $(env_setup) cmake
 DEB_CMAKE_INSTALL_PREFIX = $(rock_install_dir)
 DEB_CMAKE_EXTRA_FLAGS = -DCMAKE_SKIP_RPATH=OFF
@@ -98,7 +98,7 @@ include /usr/share/cdbs/1/class/cmake.mk
 # ##########################################
 #
 <% else 
-raise "debian/rules: cannot handle package type #{package.class} for #{package.name}"
+raise "debian/rules: cannot handle package type #{package_info.build_type} for #{package_info.name}"
 end %>
 
 # http://cdbs-doc.duckcorp.org/en/cdbs-doc.xhtml see post-configure actions
@@ -106,14 +106,14 @@ end %>
 #   (a) guarantee that pkgconfig can still knowns the include directory (-I)
 #   (b) the include directory is actually accounted for as system include directory (-isystem)
 # Account for the fact, that configure is called multiple times e.g. revert changes first, then reapply
-configure/<%=debian_name(package,true) %>::
+configure/<%= debian_name %>::
 	echo "Adapt -I to -isystem in pkgconfig files:"
 	find . -name '[a-zA-Z]*.pc' -exec sh -c "echo Adapting {}; sed -i 's#\(\"\?\)-isystem[^ ]\+\1##g; s#\(\"\?\)-I\([^ ]\+\)\1#\1-I\2\1 \1-isystem\2\1#g; s#[ ]\+# #g' {}; cat {};" \;
 
 ###########################################
 # DOCS
 
-<% if package.class == Autobuild::CMake || package.class == Autobuild::Orogen || package.class == Autobuild::Autotools %>
+<% if package_info.build_type == :orogen || package_info.build_type == :cmake || package_info.build_type == :autotools %>
 
 # Build docs
 # This checks for Doxyfile and runs doxygen with that.

--- a/lib/rock/packaging/templates/debian/rules
+++ b/lib/rock/packaging/templates/debian/rules
@@ -86,7 +86,7 @@ include /usr/share/cdbs/1/rules/autoreconf.mk
 ############################################
 # BEGIN IMPORTER
 #
-<% elsif package.importer.kind_of?(Autobuild::ArchiveImporter) || package.kind_of?(Autobuild::ImporterPackage) %>
+<% elsif package.importer.kind_of?(Autobuild::ArchiveImporter) || package.kind_of?(Autobuild::ImporterPackage) || package.name =~ /bundles/ %>
 CMAKE = $(env_setup) cmake
 DEB_CMAKE_INSTALL_PREFIX = $(rock_install_dir)
 DEB_CMAKE_EXTRA_FLAGS = -DCMAKE_SKIP_RPATH=OFF

--- a/lib/rock/packaging/templates/debian/rules
+++ b/lib/rock/packaging/templates/debian/rules
@@ -86,7 +86,7 @@ include /usr/share/cdbs/1/rules/autoreconf.mk
 ############################################
 # BEGIN IMPORTER
 #
-<% elsif package.importer.kind_of?(Autobuild::ArchiveImporter) || package.kind_of?(Autobuild::ImporterPackage) || package.name =~ /bundles/ %>
+<% elsif package.importer.kind_of?(Autobuild::ArchiveImporter) || package.kind_of?(Autobuild::ImporterPackage) || package_info.name =~ /bundles/ %>
 CMAKE = $(env_setup) cmake
 DEB_CMAKE_INSTALL_PREFIX = $(rock_install_dir)
 DEB_CMAKE_EXTRA_FLAGS = -DCMAKE_SKIP_RPATH=OFF

--- a/lib/rock/packaging/templates/debian/rules
+++ b/lib/rock/packaging/templates/debian/rules
@@ -108,7 +108,7 @@ end %>
 # Account for the fact, that configure is called multiple times e.g. revert changes first, then reapply
 configure/<%=debian_name(package,true) %>::
 	echo "Adapt -I to -isystem in pkgconfig files:"
-	find . -name '[a-zA-Z]*.pc' -exec sh -c "echo Adapting {}; sed -i 's#-isystem[^ ]\+##g' {}; sed -i 's#-I\([^ ]\+\)#-I\1 -isystem\1#g' {}; sed -i 's#[ ]\+# #g' {}; cat {};" \;
+	find . -name '[a-zA-Z]*.pc' -exec sh -c "echo Adapting {}; sed -i 's#\(\"\?\)-isystem[^ ]\+\1##g; s#\(\"\?\)-I\([^ ]\+\)\1#\1-I\2\1 \1-isystem\2\1#g; s#[ ]\+# #g' {}; cat {};" \;
 
 ###########################################
 # DOCS

--- a/lib/rock/packaging/templates/jenkins-flow-job.xml
+++ b/lib/rock/packaging/templates/jenkins-flow-job.xml
@@ -37,11 +37,11 @@ retry(3) {
 }
     <% end %>
 
-    <% flow[:packages].each_with_index do |pkg,i| %>
+    <% flow[:pkginfos].each_with_index do |pkginfo,i| %>
 retry(3) {
-    build(&quot;0_cleanup-package&quot;, release: &quot;<%= flavor %>&quot;, package: &quot;<%= debian_packager.debian_name(pkg, true) %>&quot;)
-    build(&quot;<%= debian_packager.debian_name(pkg, false) %>&quot;, release: &quot;<%=  flavor %>&quot;)
-    build(&quot;0_update-osdeps-lists&quot;, release: &quot;<%= flavor %>&quot;, package: &quot;<%= pkg.name %>&quot;)
+    build(&quot;0_cleanup-package&quot;, release: &quot;<%= flavor %>&quot;, package: &quot;<%= debian_packager.debian_name_i(pkginfo, true) %>&quot;)
+    build(&quot;<%= debian_packager.debian_name_i(pkginfo, false) %>&quot;, release: &quot;<%=  flavor %>&quot;)
+    build(&quot;0_update-osdeps-lists&quot;, release: &quot;<%= flavor %>&quot;, package: &quot;<%= pkginfo.name %>&quot;)
 }
     <% end %>
 </dsl>

--- a/lib/rock/packaging/templates/jenkins-flow-job.xml
+++ b/lib/rock/packaging/templates/jenkins-flow-job.xml
@@ -39,8 +39,8 @@ retry(3) {
 
     <% flow[:pkginfos].each_with_index do |pkginfo,i| %>
 retry(3) {
-    build(&quot;0_cleanup-package&quot;, release: &quot;<%= flavor %>&quot;, package: &quot;<%= debian_packager.debian_name_i(pkginfo, true) %>&quot;)
-    build(&quot;<%= debian_packager.debian_name_i(pkginfo, false) %>&quot;, release: &quot;<%=  flavor %>&quot;)
+    build(&quot;0_cleanup-package&quot;, release: &quot;<%= flavor %>&quot;, package: &quot;<%= debian_packager.debian_name(pkginfo, true) %>&quot;)
+    build(&quot;<%= debian_packager.debian_name(pkginfo, false) %>&quot;, release: &quot;<%=  flavor %>&quot;)
     build(&quot;0_update-osdeps-lists&quot;, release: &quot;<%= flavor %>&quot;, package: &quot;<%= pkginfo.name %>&quot;)
 }
     <% end %>

--- a/test/test_packaging.rb
+++ b/test/test_packaging.rb
@@ -82,7 +82,7 @@ class TestDebian < Minitest::Test
     end
 
     def test_recursive_dependencies
-        test_set = { "utilrb" => ["rake", "rubygems-integration", "bundler", "ruby-facets", "rake-compiler", "ruby-flexmock"],
+        test_set = { "utilrb" => ["rake", "rubygems-integration", "bundler", "ruby-facets"],
                      "rtt"  => ["cmake","omniidl","libomniorb4-dev","omniorb-nameserver",
                                 "libboost-dev","libboost-graph-dev","libboost-program-options-dev",
                                 "libboost-regex-dev","libboost-thread-dev","libboost-filesystem-dev",

--- a/test/test_packaging.rb
+++ b/test/test_packaging.rb
@@ -114,7 +114,7 @@ class TestDebian < Minitest::Test
     end
 
     def test_orig_tgz
-        gems= ['rice','websocket','state_machine','rb-readline','concurrent-ruby','qtbindings','tty-cursor','debug_inspector','equatable','tty-color','uber','lazy_priority_queue','stream','necromancer','wisper','tty-screen','unicode-display_width','enumerable-lazy','websocket-extensions','unicode_utils','ice_nine','hoe-yard','binding_of_caller','concurrent-ruby-ext','pastel','hooks','rgl','mustermannwebsocket-driver','descendants_tracker','faye-websocket','tty-prompt','tty-table','axiom-types','coercible','virtus',['grape','0.16.2'],'grape_logging']
+        gems= ['rice','websocket','state_machine','rb-readline','concurrent-ruby','qtbindings','tty-cursor','debug_inspector','equatable','tty-color','uber','lazy_priority_queue','stream','necromancer','wisper','tty-screen','unicode-display_width','enumerable-lazy','websocket-extensions','unicode_utils','ice_nine','hoe-yard','binding_of_caller','concurrent-ruby-ext','pastel','hooks','rgl','mustermann','websocket-driver','descendants_tracker','faye-websocket','tty-prompt','tty-table','axiom-types','coercible','virtus',['grape','0.16.2'],'grape_logging']
 
         require 'digest'
 

--- a/test/test_packaging.rb
+++ b/test/test_packaging.rb
@@ -102,7 +102,7 @@ class TestDebian < Minitest::Test
         ["base/cmake","utilrb"].each do |pkg_name|
             pkg = packager.package_by_name(pkg_name)
             packager.package(pkg)
-            ["debian.tar.gz", "dsc","orig.tar.gz"].each do |suffix|
+            ["debian.tar.{gz,xz}", "dsc","orig.tar.gz"].each do |suffix|
                 files = Dir.glob(File.join(packager.packaging_dir(pkg), "*.#{suffix}"))
                 assert(files.size == 1, "File with suffix #{suffix} generated")
             end


### PR DESCRIPTION
This separates out accesses to autoproj (and autobuild) internal structures. The patch series is split into preparatory work, mostly splitting functions in two, then copying functions over to the autoproj facing parts, implementing an information gathering function, moving over to using that function and finally cleaning up by removing the now unused functions.